### PR TITLE
feat: add WebRTC streaming option to camera agent

### DIFF
--- a/docker/camera-agent/Dockerfile
+++ b/docker/camera-agent/Dockerfile
@@ -1,5 +1,7 @@
 # /docker/camera-agent/Dockerfile
-FROM python:3.10-slim
+FROM --platform=$BUILDPLATFORM python:3.10-slim
+
+ARG TARGETPLATFORM
 
 # Avoid Python buffering so logs appear in real‐time
 ENV PYTHONUNBUFFERED=1
@@ -11,6 +13,8 @@ RUN apt-get update \
       libsm6 \
       libxext6 \
       libxrender1 \
+      libatlas3-base \
+      libjpeg62-turbo \
       avahi-utils \
  && rm -rf /var/lib/apt/lists/*
 

--- a/docker/camera-agent/README.md
+++ b/docker/camera-agent/README.md
@@ -2,7 +2,7 @@
 
 #### Author: David Cannan
 
-A lightweight Python agent that turns any device with a camera into a remote video source for the That DAM Toolbox system. The agent automatically discovers gateways via mDNS, registers itself, and streams JPEG frames over WebSocket.
+A lightweight Python agent that turns any device with a camera into a remote video source for the That DAM Toolbox system. The agent automatically discovers gateways via mDNS, registers itself, and streams video over WebSocket or WebRTC.
 
 ⸻
 
@@ -10,7 +10,7 @@ A lightweight Python agent that turns any device with a camera into a remote vid
 
 - **Auto-discovery** – Finds That DAM Toolbox gateways advertising `_thatdam._tcp` via mDNS
 - **Self-registration** – Registers with the gateway and persists credentials locally
-- **Video streaming** – Captures frames from `/dev/video*` and streams over WebSocket
+- **Video streaming** – Captures frames from `/dev/video*` and streams over WebSocket or WebRTC
 - **Persistent config** – Saves registration info to `/data/agent.yaml` for reconnects
 - **Resilient reconnection** – Exponential backoff reconnection with clean shutdown
 - **Minimal footprint** – Runs anywhere Python + OpenCV can run
@@ -64,6 +64,7 @@ The agent captures frames at configurable resolution/FPS, encodes as JPEG with q
 |`FRAME_H`         |`360`     |Frame height in pixels                 |
 |`FPS`             |`10`      |Frames per second                      |
 |`GATEWAY_URL`     |(none)    |Static gateway override (bypasses mDNS)|
+|`STREAM_MODE`     |`ws-jpeg` |Streaming mode: `ws-jpeg` or `webrtc`  |
 
 ### Persistent Configuration
 
@@ -86,6 +87,16 @@ This allows the agent to reconnect without re-registering after restarts.
 ```bash
 cd docker/camera-agent
 docker build -t camera-agent:latest .
+```
+
+### Multi-arch build (e.g. Raspberry Pi Zero 2 W)
+
+Use Docker Buildx to target ARM platforms:
+
+```bash
+docker buildx build --platform linux/arm/v7 -t camera-agent:pi .
+# or for 64-bit
+docker buildx build --platform linux/arm64 -t camera-agent:pi .
 ```
 
 ### Run standalone

--- a/docker/camera-agent/camera_agent.py
+++ b/docker/camera-agent/camera_agent.py
@@ -9,35 +9,41 @@ ThatDAM Camera-Agent
   frames over a WebSocket at /ws/camera?deviceId=<id>
 • reconnects forever with back-off; CTRL-C / SIGTERM exits cleanly
 """
-import asyncio, base64, json, os, signal, sys, time
+import asyncio, base64, json, os, signal, time
 from pathlib import Path
 from typing import Optional
 
-import aiohttp, cv2, websockets
+import aiohttp
+import cv2
+import websockets
+from aiortc import RTCPeerConnection, RTCSessionDescription, VideoStreamTrack
+import av
 from zeroconf.asyncio import AsyncServiceBrowser, AsyncZeroconf
 
 ###############################################################################
 # Config helpers
 ###############################################################################
 
-DATA_DIR      = Path(os.getenv("DATA_DIR", "/data"))
-CFG_PATH      = DATA_DIR / "agent.yaml"
-SERVICE_TYPE  = "_thatdam._tcp.local."
+DATA_DIR = Path(os.getenv("DATA_DIR", "/data"))
+CFG_PATH = DATA_DIR / "agent.yaml"
+SERVICE_TYPE = "_thatdam._tcp.local."
 REGISTER_PATH = "/api/devices/register"
-WELL_KNOWN    = "/.well-known/thatdam.json"
+WELL_KNOWN = "/.well-known/thatdam.json"
 
 # Defaults can be overridden via env for quick tests
 DEVICE_SERIAL = os.getenv("DEVICE_SERIAL", os.uname().nodename)
-CAPTURE_ID    = int(os.getenv("VIDEO_DEVICE_IDX", "0"))
-FRAME_W       = int(os.getenv("FRAME_W", "640"))
-FRAME_H       = int(os.getenv("FRAME_H", "360"))
-FPS           = float(os.getenv("FPS", "10"))
+CAPTURE_ID = int(os.getenv("VIDEO_DEVICE_IDX", "0"))
+FRAME_W = int(os.getenv("FRAME_W", "640"))
+FRAME_H = int(os.getenv("FRAME_H", "360"))
+FPS = float(os.getenv("FPS", "10"))
+STREAM_MODE = os.getenv("STREAM_MODE")
 
 ###############################################################################
 # Utility I/O
 ###############################################################################
 
 import yaml  # late import so PyYAML only needed in the image
+
 
 def load_cfg() -> Optional[dict]:
     if CFG_PATH.exists():
@@ -56,13 +62,14 @@ def persist_cfg(cfg: dict) -> None:
 # Discovery / registration
 ###############################################################################
 
+
 async def discover_gateway(timeout: int = 8) -> Optional[str]:
     """Return first host (e.g. dam-pi.local) that advertises SERVICE_TYPE."""
     found: asyncio.Future[str | None] = asyncio.get_event_loop().create_future()
 
     async def on_service(state, _type, name):
         if state.is_added():
-            host = name.rstrip("."+SERVICE_TYPE)
+            host = name.rstrip("." + SERVICE_TYPE)
             if not found.done():
                 found.set_result(host)
 
@@ -75,14 +82,20 @@ async def discover_gateway(timeout: int = 8) -> Optional[str]:
         finally:
             await browser.async_cancel()
 
+
 async def fetch_well_known(host: str) -> dict:
     async with aiohttp.ClientSession() as s:
         async with s.get(f"http://{host}{WELL_KNOWN}", timeout=4) as r:
             r.raise_for_status()
             return await r.json()
 
+
 async def register(host: str, token: str) -> dict:
-    payload = {"serial": DEVICE_SERIAL, "model": "raspberrypi-camera"}
+    payload = {
+        "serial": DEVICE_SERIAL,
+        "model": "raspberrypi-camera",
+        "stream_mode": STREAM_MODE or "ws-jpeg",
+    }
     async with aiohttp.ClientSession() as s:
         async with s.post(
             f"http://{host}{REGISTER_PATH}",
@@ -92,6 +105,7 @@ async def register(host: str, token: str) -> dict:
         ) as r:
             r.raise_for_status()
             return await r.json()
+
 
 async def ensure_config() -> dict:
     """Load existing configuration or perform discovery / registration."""
@@ -109,16 +123,19 @@ async def ensure_config() -> dict:
     meta = await fetch_well_known(gw_host)
     cfg = await register(gw_host, meta["reg_token"])
     cfg["gateway"] = gw_host
+    cfg["stream_mode"] = STREAM_MODE or "ws-jpeg"
     persist_cfg(cfg)
     return cfg
 
+
 ###############################################################################
-# Video capture + WebSocket
+# Video capture loops
 ###############################################################################
 
-async def cam_loop(cfg: dict):
-    device_id   = cfg["device_id"]
-    ws_url      = f"ws://{cfg['gateway']}:8080/ws/camera?deviceId={device_id}"
+
+async def cam_loop_ws(cfg: dict):
+    device_id = cfg["device_id"]
+    ws_url = f"ws://{cfg['gateway']}:8080/ws/camera?deviceId={device_id}"
 
     cap = cv2.VideoCapture(CAPTURE_ID)
     cap.set(cv2.CAP_PROP_FRAME_WIDTH, FRAME_W)
@@ -138,7 +155,9 @@ async def cam_loop(cfg: dict):
                         if not ret:
                             await asyncio.sleep(0.5)
                             continue
-                        _, buf = cv2.imencode(".jpg", frame, [int(cv2.IMWRITE_JPEG_QUALITY), 80])
+                        _, buf = cv2.imencode(
+                            ".jpg", frame, [int(cv2.IMWRITE_JPEG_QUALITY), 80]
+                        )
                         await ws.send(
                             json.dumps(
                                 {
@@ -155,23 +174,98 @@ async def cam_loop(cfg: dict):
     finally:
         cap.release()
 
+
+class OpenCVCaptureTrack(VideoStreamTrack):
+    """VideoStreamTrack that grabs frames from OpenCV."""
+
+    def __init__(self, cap: cv2.VideoCapture):
+        super().__init__()
+        self.cap = cap
+
+    async def recv(self):
+        pts, time_base = await self.next_timestamp()
+        ret, frame = self.cap.read()
+        if not ret:
+            await asyncio.sleep(1 / FPS)
+            return await self.recv()
+        frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+        frame = av.VideoFrame.from_ndarray(frame, format="rgb24")
+        frame.pts = pts
+        frame.time_base = time_base
+        return frame
+
+
+async def cam_loop_webrtc(cfg: dict):
+    device_id = cfg["device_id"]
+    url = f"http://{cfg['gateway']}:8080/webrtc?deviceId={device_id}"
+
+    cap = cv2.VideoCapture(CAPTURE_ID)
+    cap.set(cv2.CAP_PROP_FRAME_WIDTH, FRAME_W)
+    cap.set(cv2.CAP_PROP_FRAME_HEIGHT, FRAME_H)
+    cap.set(cv2.CAP_PROP_FPS, FPS)
+
+    if not cap.isOpened():
+        raise RuntimeError("Unable to open /dev/video*")
+
+    try:
+        async for backoff in reconnect(backoff_initial=1, backoff_max=30):
+            pc = RTCPeerConnection()
+            track = OpenCVCaptureTrack(cap)
+            pc.addTrack(track)
+            try:
+                offer = await pc.createOffer()
+                await pc.setLocalDescription(offer)
+                async with aiohttp.ClientSession() as s:
+                    async with s.post(
+                        url,
+                        json={
+                            "sdp": pc.localDescription.sdp,
+                            "type": pc.localDescription.type,
+                        },
+                        timeout=5,
+                    ) as r:
+                        r.raise_for_status()
+                        ans = await r.json()
+                await pc.setRemoteDescription(
+                    RTCSessionDescription(ans["sdp"], ans["type"])
+                )
+                print(f"[agent] WebRTC connected → {url}")
+                while pc.connectionState not in ("failed", "closed"):
+                    await asyncio.sleep(1)
+            except Exception as e:
+                print(f"[agent] WebRTC error: {e}")
+                await asyncio.sleep(backoff)
+            finally:
+                await pc.close()
+    finally:
+        cap.release()
+
+
 def reconnect(backoff_initial=1, backoff_max=30):
     backoff = backoff_initial
     while True:
         yield backoff
         backoff = min(backoff * 2, backoff_max)
 
+
 ###############################################################################
 # Main
 ###############################################################################
 
+
 async def main():
     cfg = await ensure_config()
-    await cam_loop(cfg)
+    mode = STREAM_MODE or cfg.get("stream_mode", "ws-jpeg")
+    if mode == "webrtc":
+        await cam_loop_webrtc(cfg)
+    else:
+        await cam_loop_ws(cfg)
+
 
 def shutdown(loop):
     for t in asyncio.all_tasks(loop):
         t.cancel()
+
 
 if __name__ == "__main__":
     loop = asyncio.new_event_loop()

--- a/docker/camera-agent/requirements.txt
+++ b/docker/camera-agent/requirements.txt
@@ -1,5 +1,7 @@
 opencv-python-headless>=4.8
 websockets>=12.0
 aiohttp>=3.9
+aiortc>=1.5
+av>=10.0
 zeroconf>=0.130
 PyYAML>=6.0


### PR DESCRIPTION
## Summary
- allow camera-agent to stream via WebSocket JPEG or WebRTC based on STREAM_MODE
- add aiortc and multi-arch Dockerfile for Raspberry Pi builds
- document STREAM_MODE and buildx usage

## Testing
- `black docker/camera-agent/camera_agent.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'video')*

------
https://chatgpt.com/codex/tasks/task_e_68937e27b0a08326913b45c377ef3679