### PR TITLE
feat: add webrtc streaming to camera agent

### DIFF
--- a/docker/camera-agent/Dockerfile
+++ b/docker/camera-agent/Dockerfile
@@ -1,10 +1,11 @@
 # /docker/camera-agent/Dockerfile
-FROM python:3.10-slim
+FROM --platform=$BUILDPLATFORM python:3.10-slim
+ARG TARGETPLATFORM
 
 # Avoid Python buffering so logs appear in real‐time
 ENV PYTHONUNBUFFERED=1
 
-# Install OS packages required by OpenCV
+# Install OS packages required by OpenCV and WebRTC
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
       libglib2.0-0 \
@@ -12,6 +13,12 @@ RUN apt-get update \
       libxext6 \
       libxrender1 \
       avahi-utils \
+      libatlas3-base \
+      libjpeg62-turbo \
+      libavdevice58 \
+      libavfilter7 \
+      libopus0 \
+      libvpx7 \
  && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/docker/camera-agent/requirements.txt
+++ b/docker/camera-agent/requirements.txt
@@ -3,3 +3,5 @@ websockets>=12.0
 aiohttp>=3.9
 zeroconf>=0.130
 PyYAML>=6.0
+aiortc>=1.6
+av>=10.0


### PR DESCRIPTION
## Summary
- allow camera-agent to stream over WebRTC or JPEG-over-WebSocket via STREAM_MODE
- support multi-arch builds and WebRTC deps in camera-agent container
- document STREAM_MODE and Pi build instructions

## Testing
- `python -m py_compile docker/camera-agent/camera_agent.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'video')*


------
https://chatgpt.com/codex/tasks/task_e_68937e27b0a08326913b45c377ef3679