### PR TITLE
[feat] add overlay hub skeleton and client

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -1,0 +1,4 @@
+version: v1
+generation:
+  go:
+    out: sdk/go

--- a/buf.yaml
+++ b/buf.yaml
@@ -1,0 +1,3 @@
+version: v1
+modules:
+  - path: proto

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -102,7 +102,7 @@ services:
     privileged: true                        # Needed for /dev and v4l2
     pid: host
     environment:
-     AMQP_URL: "amqp://video:video@rabbitmq:5672/"
+     EVENT_BROKER_URL: "amqp://video:video@rabbitmq:5672/"
      REGISTRY_URL: "docker.io/cdaprod/capture-daemon:latest"  # Or your actual registry/repo URL
      CAPTURE_OUTDIR: "/records"
     volumes:

--- a/docker/compose/docker-compose.infra.yaml
+++ b/docker/compose/docker-compose.infra.yaml
@@ -126,3 +126,13 @@ services:
 # (No changes here to your main video-api stack – it remains in the
 # root compose file and can be started alone or with –f infra.yaml)
 # ──────────────────────────────────────────────────────────────
+  overlay-hub:
+    build:
+      context: ../../host/services/overlay-hub
+    ports: ["8090:8090"]
+    networks: [damnet]
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8090/healthz"]
+      interval: 10s
+      timeout: 5s
+      retries: 5

--- a/docker/web-app/packages/eventbus/index.js
+++ b/docker/web-app/packages/eventbus/index.js
@@ -7,7 +7,10 @@ const amqplib = require('amqplib');
 
 let connection; let channel; let exchange = 'events';
 
-async function connect(url = process.env.AMQP_URL || 'amqp://localhost/', ex = process.env.AMQP_EXCHANGE || 'events') {
+async function connect(
+  url = process.env.EVENT_BROKER_URL || process.env.AMQP_URL || 'amqp://localhost/',
+  ex = process.env.AMQP_EXCHANGE || 'events'
+) {
   if (!connection) {
     exchange = ex;
     connection = await amqplib.connect(url);

--- a/docs/TECHNICAL/AGENTS.md
+++ b/docs/TECHNICAL/AGENTS.md
@@ -111,6 +111,7 @@ This file equips you with everything required to ship safe, idempotent, idiomati
 ### rabbitmq (docker/rabbitmq/*)
 
 - System event broker
+- All services read the connection string from `EVENT_BROKER_URL` (falling back to `AMQP_URL`)
 
 ### nginx (docker/nginx/*)
 

--- a/go.work
+++ b/go.work
@@ -4,5 +4,6 @@ use (
 	./host/services/api-gateway
 	./host/services/camera-proxy
         ./host/services/capture-daemon
+        ./host/services/overlay-hub
         ./host/services/shared
 )

--- a/host/services/api-gateway/README.md
+++ b/host/services/api-gateway/README.md
@@ -14,3 +14,7 @@ docker run -p 8080:8080 api-gateway
 docker compose -f host/services/api-gateway/docker-compose.api-gateway.yaml --profile api-gateway up
 ```
 
+## Overlay endpoints
+- `POST /agents/issue`
+- `GET /.well-known/jwks.json`
+- `GET /overlay/hints`

--- a/host/services/api-gateway/cmd/main.go
+++ b/host/services/api-gateway/cmd/main.go
@@ -2,232 +2,233 @@
 package main
 
 import (
-    "context"
-    "flag"
-    "fmt"
-    "io"
-    "log"
-    "net/http"
-    "os"
-    "os/signal"
-    "path/filepath"
-    "strconv"
-    "strings"
-    "syscall"
-    "time"
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
 
-    "github.com/gorilla/websocket"
+	"github.com/gorilla/websocket"
 
-    "github.com/Cdaprod/ThatDamToolbox/host/services/api-gateway/pkg/middleware"
-    "github.com/Cdaprod/ThatDamToolbox/host/services/shared/middleware/backend"
-    "github.com/Cdaprod/ThatDamToolbox/host/services/shared/middleware/frontend"
-    "github.com/Cdaprod/ThatDamToolbox/host/services/shared/middleware/host"
+	"github.com/Cdaprod/ThatDamToolbox/host/services/api-gateway/pkg/middleware"
+	"github.com/Cdaprod/ThatDamToolbox/host/services/shared/middleware/backend"
+	"github.com/Cdaprod/ThatDamToolbox/host/services/shared/middleware/frontend"
+	"github.com/Cdaprod/ThatDamToolbox/host/services/shared/middleware/host"
 )
 
 var wsUpgrader = websocket.Upgrader{
-    CheckOrigin: func(r *http.Request) bool { return true },
+	CheckOrigin: func(r *http.Request) bool { return true },
 }
 
 func main() {
-    // 1) Configuration via flags
-    addr       := flag.String("addr", ":8080", "HTTP bind address")
-    apiPrefix  := flag.String("api-prefix", "/api/", "API route prefix")
-    backendURL := flag.String("backend-url", "http://localhost:8000", "Upstream backend URL")
-    jwtSecret  := flag.String("jwt-secret", "your-jwt-secret", "JWT signing secret")
-    staticDir  := flag.String("static-dir", filepath.Join("docker", "web-app", "build"), "SPA build directory")
-    mediaDir   := flag.String("media-dir", "/data/media", "Media directory path")
-    dbPath     := flag.String("db-path", "/data/db/live.sqlite3", "Path to SQLite DB")
-    cacheDur   := flag.Duration("cache", 5*time.Minute, "Backend cache duration")
-    rlPerMin   := flag.Int("rate-limit", 60, "Requests per minute")
-    flag.Parse()
+	// 1) Configuration via flags
+	addr := flag.String("addr", ":8080", "HTTP bind address")
+	apiPrefix := flag.String("api-prefix", "/api/", "API route prefix")
+	backendURL := flag.String("backend-url", "http://localhost:8000", "Upstream backend URL")
+	jwtSecret := flag.String("jwt-secret", "your-jwt-secret", "JWT signing secret")
+	staticDir := flag.String("static-dir", filepath.Join("docker", "web-app", "build"), "SPA build directory")
+	mediaDir := flag.String("media-dir", "/data/media", "Media directory path")
+	dbPath := flag.String("db-path", "/data/db/live.sqlite3", "Path to SQLite DB")
+	cacheDur := flag.Duration("cache", 5*time.Minute, "Backend cache duration")
+	rlPerMin := flag.Int("rate-limit", 60, "Requests per minute")
+	flag.Parse()
 
-    // 2) Base mux & handlers
-    mux := http.NewServeMux()
-    mux.HandleFunc(*apiPrefix+"health", healthHandler)
-    mux.HandleFunc(*apiPrefix+"video/", videoHandler)
-    mux.HandleFunc("/", frontendHandler)
+	// 2) Base mux & handlers
+	mux := http.NewServeMux()
+	mux.HandleFunc(*apiPrefix+"health", healthHandler)
+	mux.HandleFunc(*apiPrefix+"video/", videoHandler)
+	mux.HandleFunc("/", frontendHandler)
+	setupOverlayRoutes(mux)
 
-    // 3) Build middleware chain
-    chain := middleware.New().
-        Use(host.SystemResourceMiddleware).
-        Use(host.ProcessLimitMiddleware(100)).
-        Use(host.FileSystemMiddleware([]string{*mediaDir, filepath.Dir(*dbPath)})).
-        Use(backend.RequestLoggingMiddleware).
-        Use(backend.RateLimitMiddleware(*rlPerMin)).
-        Use(backend.APIGatewayMiddleware(map[string]string{
-            *apiPrefix: *backendURL,
-        })).
-        Use(backend.AuthenticationMiddleware(*jwtSecret)).
-        Use(backend.CacheMiddleware(*cacheDur)).
-        Use(frontend.CSPMiddleware("default-src 'self'; script-src 'self' 'unsafe-inline'")).
-        Use(frontend.StaticFileMiddleware(*staticDir, 24*time.Hour)).
-        Use(frontend.SPAMiddleware(filepath.Join(*staticDir, "index.html"))).
-        Use(frontend.CompressionMiddleware).
-        // custom:
-        Use(MediaStreamingMiddleware(*mediaDir)).
-        Use(WebSocketUpgradeMiddleware).
-        Use(DatabaseConnectionMiddleware(*dbPath))
+	// 3) Build middleware chain
+	chain := middleware.New().
+		Use(host.SystemResourceMiddleware).
+		Use(host.ProcessLimitMiddleware(100)).
+		Use(host.FileSystemMiddleware([]string{*mediaDir, filepath.Dir(*dbPath)})).
+		Use(backend.RequestLoggingMiddleware).
+		Use(backend.RateLimitMiddleware(*rlPerMin)).
+		Use(backend.APIGatewayMiddleware(map[string]string{
+			*apiPrefix: *backendURL,
+		})).
+		Use(backend.AuthenticationMiddleware(*jwtSecret)).
+		Use(backend.CacheMiddleware(*cacheDur)).
+		Use(frontend.CSPMiddleware("default-src 'self'; script-src 'self' 'unsafe-inline'")).
+		Use(frontend.StaticFileMiddleware(*staticDir, 24*time.Hour)).
+		Use(frontend.SPAMiddleware(filepath.Join(*staticDir, "index.html"))).
+		Use(frontend.CompressionMiddleware).
+		// custom:
+		Use(MediaStreamingMiddleware(*mediaDir)).
+		Use(WebSocketUpgradeMiddleware).
+		Use(DatabaseConnectionMiddleware(*dbPath))
 
-    handler := chain.Build(mux)
+	handler := chain.Build(mux)
 
-    // 4) HTTP server with timeouts
-    srv := &http.Server{
-        Addr:         *addr,
-        Handler:      handler,
-        ReadTimeout:  5 * time.Second,
-        WriteTimeout: 10 * time.Second,
-        IdleTimeout:  120 * time.Second,
-    }
+	// 4) HTTP server with timeouts
+	srv := &http.Server{
+		Addr:         *addr,
+		Handler:      handler,
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 10 * time.Second,
+		IdleTimeout:  120 * time.Second,
+	}
 
-    // 5) Start & graceful shutdown
-    go func() {
-        log.Printf("🚀 Listening on %s", *addr)
-        if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-            log.Fatalf("ListenAndServe: %v", err)
-        }
-    }()
+	// 5) Start & graceful shutdown
+	go func() {
+		log.Printf("🚀 Listening on %s", *addr)
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatalf("ListenAndServe: %v", err)
+		}
+	}()
 
-    stop := make(chan os.Signal, 1)
-    signal.Notify(stop, os.Interrupt, syscall.SIGTERM)
-    <-stop
+	stop := make(chan os.Signal, 1)
+	signal.Notify(stop, os.Interrupt, syscall.SIGTERM)
+	<-stop
 
-    log.Println("⚙️  Shutting down…")
-    ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-    defer cancel()
-    if err := srv.Shutdown(ctx); err != nil {
-        log.Fatalf("Shutdown error: %v", err)
-    }
-    log.Println("✅ Shutdown complete")
+	log.Println("⚙️  Shutting down…")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := srv.Shutdown(ctx); err != nil {
+		log.Fatalf("Shutdown error: %v", err)
+	}
+	log.Println("✅ Shutdown complete")
 }
 
 // Handlers
 func healthHandler(w http.ResponseWriter, r *http.Request) {
-    w.Header().Set("Content-Type", "application/json")
-    w.WriteHeader(http.StatusOK)
-    w.Write([]byte(`{"status":"healthy"}`))
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte(`{"status":"healthy"}`))
 }
 
 func videoHandler(w http.ResponseWriter, r *http.Request) {
-    // Proxy /video/ to your Python backend API via APIGatewayMiddleware.
-    // This stub simply returns JSON; remove if APIGatewayMiddleware handles it.
-    w.Header().Set("Content-Type", "application/json")
-    w.Write([]byte(`{"message":"Video API endpoint"}`))
+	// Proxy /video/ to your Python backend API via APIGatewayMiddleware.
+	// This stub simply returns JSON; remove if APIGatewayMiddleware handles it.
+	w.Header().Set("Content-Type", "application/json")
+	w.Write([]byte(`{"message":"Video API endpoint"}`))
 }
 
 func frontendHandler(w http.ResponseWriter, r *http.Request) {
-    w.Write([]byte("Frontend content"))
+	w.Write([]byte("Frontend content"))
 }
 
 // MediaStreamingMiddleware handles Range requests at /stream/
 func MediaStreamingMiddleware(mediaPath string) func(http.Handler) http.Handler {
-    return func(next http.Handler) http.Handler {
-        return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-            if strings.HasPrefix(r.URL.Path, "/stream/") {
-                handleVideoStream(w, r, mediaPath)
-                return
-            }
-            next.ServeHTTP(w, r)
-        })
-    }
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if strings.HasPrefix(r.URL.Path, "/stream/") {
+				handleVideoStream(w, r, mediaPath)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
 }
 
 func handleVideoStream(w http.ResponseWriter, r *http.Request, mediaPath string) {
-    videoID := strings.TrimPrefix(r.URL.Path, "/stream/")
-    filePath := filepath.Join(mediaPath, videoID)
+	videoID := strings.TrimPrefix(r.URL.Path, "/stream/")
+	filePath := filepath.Join(mediaPath, videoID)
 
-    f, err := os.Open(filePath)
-    if err != nil {
-        http.NotFound(w, r)
-        return
-    }
-    defer f.Close()
+	f, err := os.Open(filePath)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	defer f.Close()
 
-    stat, err := f.Stat()
-    if err != nil {
-        http.Error(w, "File stat error", http.StatusInternalServerError)
-        return
-    }
+	stat, err := f.Stat()
+	if err != nil {
+		http.Error(w, "File stat error", http.StatusInternalServerError)
+		return
+	}
 
-    size := stat.Size()
-    w.Header().Set("Content-Type", "video/mp4")
-    w.Header().Set("Accept-Ranges", "bytes")
+	size := stat.Size()
+	w.Header().Set("Content-Type", "video/mp4")
+	w.Header().Set("Accept-Ranges", "bytes")
 
-    if rng := r.Header.Get("Range"); rng != "" {
-        handleRangeRequest(w, r, f, size)
-        return
-    }
+	if rng := r.Header.Get("Range"); rng != "" {
+		handleRangeRequest(w, r, f, size)
+		return
+	}
 
-    // No Range header → full content
-    w.Header().Set("Content-Length", strconv.FormatInt(size, 10))
-    http.ServeContent(w, r, stat.Name(), stat.ModTime(), f)
+	// No Range header → full content
+	w.Header().Set("Content-Length", strconv.FormatInt(size, 10))
+	http.ServeContent(w, r, stat.Name(), stat.ModTime(), f)
 }
 
 // handleRangeRequest serves a single byte-range (no multipart)
 func handleRangeRequest(w http.ResponseWriter, r *http.Request, f *os.File, size int64) {
-    ranges, err := http.ParseRange(r.Header.Get("Range"), size)
-    if err != nil || len(ranges) == 0 {
-        // Fallback: serve full
-        http.ServeContent(w, r, f.Name(), time.Now(), f)
-        return
-    }
-    ra := ranges[0]
-    start, length := ra.Start, ra.Length
-    end := start + length - 1
+	ranges, err := http.ParseRange(r.Header.Get("Range"), size)
+	if err != nil || len(ranges) == 0 {
+		// Fallback: serve full
+		http.ServeContent(w, r, f.Name(), time.Now(), f)
+		return
+	}
+	ra := ranges[0]
+	start, length := ra.Start, ra.Length
+	end := start + length - 1
 
-    w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, size))
-    w.Header().Set("Content-Length", strconv.FormatInt(length, 10))
-    w.WriteHeader(http.StatusPartialContent)
+	w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, size))
+	w.Header().Set("Content-Length", strconv.FormatInt(length, 10))
+	w.WriteHeader(http.StatusPartialContent)
 
-    f.Seek(start, io.SeekStart)
-    io.CopyN(w, f, length)
+	f.Seek(start, io.SeekStart)
+	io.CopyN(w, f, length)
 }
 
 // WebSocketUpgradeMiddleware upgrades /ws/ to a simple echo server
 func WebSocketUpgradeMiddleware(next http.Handler) http.Handler {
-    return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-        if strings.HasPrefix(r.URL.Path, "/ws/") {
-            handleWebSocketUpgrade(w, r)
-            return
-        }
-        next.ServeHTTP(w, r)
-    })
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/ws/") {
+			handleWebSocketUpgrade(w, r)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
 }
 
 func handleWebSocketUpgrade(w http.ResponseWriter, r *http.Request) {
-    conn, err := wsUpgrader.Upgrade(w, r, nil)
-    if err != nil {
-        log.Printf("WebSocket upgrade error: %v", err)
-        return
-    }
-    defer conn.Close()
+	conn, err := wsUpgrader.Upgrade(w, r, nil)
+	if err != nil {
+		log.Printf("WebSocket upgrade error: %v", err)
+		return
+	}
+	defer conn.Close()
 
-    for {
-        mt, msg, err := conn.ReadMessage()
-        if err != nil {
-            break
-        }
-        // Echo back
-        if err := conn.WriteMessage(mt, msg); err != nil {
-            break
-        }
-    }
+	for {
+		mt, msg, err := conn.ReadMessage()
+		if err != nil {
+			break
+		}
+		// Echo back
+		if err := conn.WriteMessage(mt, msg); err != nil {
+			break
+		}
+	}
 }
 
 // DatabaseConnectionMiddleware: basic file‐exists health check
 func DatabaseConnectionMiddleware(dbPath string) func(http.Handler) http.Handler {
-    return func(next http.Handler) http.Handler {
-        return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-            if !isDatabaseHealthy(dbPath) {
-                http.Error(w, "Database unavailable", http.StatusServiceUnavailable)
-                return
-            }
-            ctx := context.WithValue(r.Context(), "db_path", dbPath)
-            next.ServeHTTP(w, r.WithContext(ctx))
-        })
-    }
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if !isDatabaseHealthy(dbPath) {
+				http.Error(w, "Database unavailable", http.StatusServiceUnavailable)
+				return
+			}
+			ctx := context.WithValue(r.Context(), "db_path", dbPath)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
 }
 
 func isDatabaseHealthy(path string) bool {
-    info, err := os.Stat(path)
-    return err == nil && !info.IsDir()
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
 }

--- a/host/services/api-gateway/cmd/overlay.go
+++ b/host/services/api-gateway/cmd/overlay.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+var overlayKey = []byte("overlay-demo-key")
+
+func setupOverlayRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("/.well-known/jwks.json", jwksHandler)
+	mux.HandleFunc("/agents/issue", issueHandler)
+	mux.HandleFunc("/overlay/hints", hintsHandler)
+}
+
+func jwksHandler(w http.ResponseWriter, r *http.Request) {
+	jwk := map[string]any{
+		"kty": "oct",
+		"kid": "overlay",
+		"k":   base64.RawURLEncoding.EncodeToString(overlayKey),
+		"alg": "HS256",
+	}
+	json.NewEncoder(w).Encode(map[string]any{"keys": []any{jwk}})
+}
+
+func issueHandler(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		AgentID string `json:"agent_id"`
+	}
+	json.NewDecoder(r.Body).Decode(&req)
+	token := signToken(req.AgentID)
+	json.NewEncoder(w).Encode(map[string]string{"token": token})
+}
+
+func hintsHandler(w http.ResponseWriter, r *http.Request) {
+	json.NewEncoder(w).Encode(map[string]any{"primary": "http://overlay-hub:8090"})
+}
+
+func signToken(agentID string) string {
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"HS256","typ":"JWT"}`))
+	payload := base64.RawURLEncoding.EncodeToString([]byte(`{"sub":"` + agentID + `","exp":` + fmt.Sprint(time.Now().Add(time.Minute).Unix()) + `}`))
+	h := hmac.New(sha256.New, overlayKey)
+	h.Write([]byte(header + "." + payload))
+	sig := base64.RawURLEncoding.EncodeToString(h.Sum(nil))
+	return header + "." + payload + "." + sig
+}

--- a/host/services/api-gateway/cmd/overlay_test.go
+++ b/host/services/api-gateway/cmd/overlay_test.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestIssueHandler(t *testing.T) {
+	mux := http.NewServeMux()
+	setupOverlayRoutes(mux)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	body, _ := json.Marshal(map[string]string{"agent_id": "a1"})
+	resp, err := http.Post(srv.URL+"/agents/issue", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status %d", resp.StatusCode)
+	}
+}

--- a/host/services/camera-proxy/main.go
+++ b/host/services/camera-proxy/main.go
@@ -661,6 +661,7 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	go proxy.startPeriodicDiscovery(ctx)
+	startOverlay(ctx)
 
 	// Setup routes
 	handler := proxy.setupRoutes()

--- a/host/services/camera-proxy/overlay.go
+++ b/host/services/camera-proxy/overlay.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"context"
+	"os"
+	"time"
+
+	"github.com/Cdaprod/ThatDamToolbox/host/services/shared/overlay"
+)
+
+func startOverlay(ctx context.Context) {
+	hub := os.Getenv("OVERLAY_HUB_URL")
+	if hub == "" {
+		return
+	}
+	c := overlay.NewClient(hub)
+	if err := c.Register(ctx, "camera-proxy"); err != nil {
+		return
+	}
+	go c.Heartbeat(ctx, 30*time.Second)
+}

--- a/host/services/camera-proxy/overlay_test.go
+++ b/host/services/camera-proxy/overlay_test.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"context"
+	"os"
+	"testing"
+)
+
+func TestStartOverlayNoURL(t *testing.T) {
+	os.Unsetenv("OVERLAY_HUB_URL")
+	startOverlay(context.Background())
+}

--- a/host/services/capture-daemon/broker/broker.go
+++ b/host/services/capture-daemon/broker/broker.go
@@ -1,7 +1,7 @@
 // host/services/capture-daemon/broker/broker.go
 //
 // Fault-tolerant RabbitMQ helper used by the capture-daemon.
-// • zero-conf dev mode  – if $AMQP_URL is empty, Publish() is a no-op.
+// • zero-conf dev mode  – if $EVENT_BROKER_URL/$AMQP_URL is empty, Publish() is a no-op.
 // • reconnect loop      – exponential back-off, loss-tolerant buffer.
 // • non-blocking API    – caller never waits on the network.
 // • Close() helper      – graceful shutdown for `go test` or SIGTERM.
@@ -20,7 +20,7 @@ import (
 )
 
 var (
-	addr         = os.Getenv("AMQP_URL")
+	addr         = firstNonEmpty(os.Getenv("EVENT_BROKER_URL"), os.Getenv("AMQP_URL"))
 	exchangeName = firstNonEmpty(os.Getenv("BROKER_EXCHANGE"), "events")
 
 	// ring-buffer defaults to 256 msgs but can be tuned via env
@@ -35,7 +35,7 @@ var (
 func Init() {
 	initOnce.Do(func() {
 		if addr == "" {
-			log.Println("[broker] AMQP_URL not set – running in in-proc mode")
+			log.Println("[broker] AMQP_URL/EVENT_BROKER_URL not set – running in in-proc mode")
 			return
 		}
 		ctx, cancel := context.WithCancel(context.Background())
@@ -55,7 +55,7 @@ func Close() {
 
 // IsConnected reports whether the broker pump is running (used by health checks).
 func IsConnected() bool {
-    return cancelFunc != nil
+	return cancelFunc != nil
 }
 
 // Envelope is what we actually serialise and send.

--- a/host/services/capture-daemon/main.go
+++ b/host/services/capture-daemon/main.go
@@ -70,6 +70,7 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	sd := shutdown.NewManager(lg.Logger, shutdownTimeout)
+	startOverlay(ctx)
 
 	// 6. Metrics server
 	if cfg.Features.Metrics.Enabled {

--- a/host/services/capture-daemon/overlay.go
+++ b/host/services/capture-daemon/overlay.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"context"
+	"os"
+	"time"
+
+	"github.com/Cdaprod/ThatDamToolbox/host/services/shared/overlay"
+)
+
+func startOverlay(ctx context.Context) {
+	hub := os.Getenv("OVERLAY_HUB_URL")
+	if hub == "" {
+		return
+	}
+	c := overlay.NewClient(hub)
+	if err := c.Register(ctx, "capture-daemon"); err != nil {
+		return
+	}
+	go c.Heartbeat(ctx, 30*time.Second)
+}

--- a/host/services/capture-daemon/overlay_test.go
+++ b/host/services/capture-daemon/overlay_test.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"context"
+	"os"
+	"testing"
+)
+
+func TestStartOverlayNoURL(t *testing.T) {
+	os.Unsetenv("OVERLAY_HUB_URL")
+	startOverlay(context.Background())
+}

--- a/host/services/overlay-hub/Dockerfile
+++ b/host/services/overlay-hub/Dockerfile
@@ -1,0 +1,11 @@
+# simple Go build
+FROM golang:1.20-alpine AS build
+WORKDIR /src
+COPY . .
+RUN go build -o overlay-hub ./cmd/overlay-hub
+
+FROM alpine:3.18
+WORKDIR /app
+COPY --from=build /src/overlay-hub /app/overlay-hub
+EXPOSE 8090
+ENTRYPOINT ["/app/overlay-hub"]

--- a/host/services/overlay-hub/README.md
+++ b/host/services/overlay-hub/README.md
@@ -1,0 +1,16 @@
+# overlay-hub
+
+A minimal hub relaying overlay agent traffic.
+
+## Usage
+
+```
+go run ./cmd/overlay-hub/main.go -addr :8090
+```
+
+Endpoints:
+- `GET /healthz`
+- `GET /metrics`
+- `POST /v1/register`
+- `POST /v1/heartbeat`
+- `POST /v1/negotiate`

--- a/host/services/overlay-hub/cmd/overlay-hub/main.go
+++ b/host/services/overlay-hub/cmd/overlay-hub/main.go
@@ -1,0 +1,44 @@
+package main
+
+// overlay-hub exposes register and heartbeat endpoints and a QUIC relay stub.
+//
+// Example:
+//   go run ./cmd/overlay-hub/main.go -addr :8090
+
+import (
+	"flag"
+	"log"
+	"net/http"
+	"time"
+)
+
+func main() {
+	addr := flag.String("addr", ":8090", "HTTP bind address")
+	flag.Parse()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	})
+	mux.HandleFunc("/metrics", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/v1/register", okHandler)
+	mux.HandleFunc("/v1/heartbeat", okHandler)
+	mux.HandleFunc("/v1/negotiate", okHandler)
+
+	srv := &http.Server{
+		Addr:         *addr,
+		Handler:      mux,
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 5 * time.Second,
+	}
+
+	log.Printf("overlay-hub listening on %s", *addr)
+	log.Fatal(srv.ListenAndServe())
+}
+
+func okHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}

--- a/host/services/overlay-hub/cmd/overlay-hub/main_test.go
+++ b/host/services/overlay-hub/cmd/overlay-hub/main_test.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestOkHandler(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/v1/register", nil)
+	w := httptest.NewRecorder()
+	okHandler(w, req)
+	if w.Result().StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Result().StatusCode)
+	}
+}

--- a/host/services/overlay-hub/go.mod
+++ b/host/services/overlay-hub/go.mod
@@ -1,0 +1,3 @@
+module github.com/Cdaprod/ThatDamToolbox/host/services/overlay-hub
+
+go 1.20

--- a/host/services/shared/bus/facade.go
+++ b/host/services/shared/bus/facade.go
@@ -37,7 +37,10 @@ func SetAdapter(fn func(Config) (Bus, error)) { adapterCtor = fn }
 func Connect(ctx context.Context, cfg Config) (Bus, error) {
 	once.Do(func() {
 		if cfg.URL == "" {
-			cfg.URL = os.Getenv("AMQP_URL")
+			cfg.URL = os.Getenv("EVENT_BROKER_URL")
+			if cfg.URL == "" {
+				cfg.URL = os.Getenv("AMQP_URL")
+			}
 		}
 		if cfg.Exchange == "" {
 			cfg.Exchange = os.Getenv("AMQP_EXCHANGE")

--- a/host/services/shared/overlay/client.go
+++ b/host/services/shared/overlay/client.go
@@ -1,0 +1,54 @@
+package overlay
+
+// Client is a minimal HTTP overlay client.
+//
+// Example:
+//  c := overlay.NewClient("http://localhost:8090")
+//  _ = c.Register(context.Background(), "agent-1")
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+type Client struct {
+	hub  string
+	http *http.Client
+}
+
+func NewClient(hub string) *Client {
+	return &Client{hub: hub, http: &http.Client{Timeout: 5 * time.Second}}
+}
+
+// Register registers an agent with the overlay hub.
+func (c *Client) Register(ctx context.Context, agentID string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.hub+"/v1/register", nil)
+	if err != nil {
+		return err
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("register: %s", resp.Status)
+	}
+	return nil
+}
+
+// Heartbeat periodically notifies the hub that the agent is alive.
+func (c *Client) Heartbeat(ctx context.Context, interval time.Duration) {
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			_, _ = c.http.Post(c.hub+"/v1/heartbeat", "application/json", nil)
+		}
+	}
+}

--- a/host/services/shared/overlay/client_test.go
+++ b/host/services/shared/overlay/client_test.go
@@ -1,0 +1,43 @@
+package overlay
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestRegister(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	c := NewClient(srv.URL)
+	if err := c.Register(context.Background(), "a1"); err != nil {
+		t.Fatalf("register failed: %v", err)
+	}
+}
+
+func TestRegisterError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	c := NewClient(srv.URL)
+	if err := c.Register(context.Background(), "a1"); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestHeartbeatCancel(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	c := NewClient(srv.URL)
+	ctx, cancel := context.WithCancel(context.Background())
+	go c.Heartbeat(ctx, 10*time.Millisecond)
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+}

--- a/proto/overlay/identity.proto
+++ b/proto/overlay/identity.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+package overlay;
+
+// AgentIdentity represents an agent instance.
+message AgentIdentity {
+  string agent_id = 1;
+}
+
+// TokenRequest asks the gateway for a signed token.
+message TokenRequest {
+  string agent_id = 1;
+  string tenant = 2;
+}
+
+// TokenResponse carries a signed JWT.
+message TokenResponse {
+  string token = 1;
+}

--- a/proto/overlay/registry.proto
+++ b/proto/overlay/registry.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+package overlay;
+
+// RegisterRequest is sent by agents to join the overlay.
+message RegisterRequest {
+  string agent_id = 1;
+}
+
+// RegisterResponse acknowledges registration.
+message RegisterResponse {
+  bool ok = 1;
+}
+
+// Heartbeat carries periodic liveness signals.
+message Heartbeat {
+  string agent_id = 1;
+  int64 ts = 2;
+}

--- a/proto/overlay/transport.proto
+++ b/proto/overlay/transport.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+package overlay;
+
+// OpenChannel requests a media/control channel.
+message OpenChannel {
+  string agent_id = 1;
+  string target_id = 2;
+  string protocol = 3; // quic or webrtc
+}
+
+// ChannelResponse acknowledges channel creation.
+message ChannelResponse {
+  bool ok = 1;
+}

--- a/scripts/systemd/overlay-hub.service
+++ b/scripts/systemd/overlay-hub.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Overlay Hub
+After=network.target
+
+[Service]
+ExecStart=/usr/local/bin/overlay-hub
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/video/core/event/rabbitmq_connector.py
+++ b/video/core/event/rabbitmq_connector.py
@@ -5,6 +5,7 @@ Async RabbitMQ backend that matches the interface expected by
 `lifecycle_hooks` (start → publish → close).
 It uses aio-pika, so keep that in your `requirements.txt`.
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -30,7 +31,7 @@ class RabbitMQBus:
 
     # ------------------------------------------------------------------ #
     async def start(self) -> None:
-        if self._conn:                                           # already open
+        if self._conn:  # already open
             return
         self._conn = await aio_pika.connect_robust(
             self._url,
@@ -43,7 +44,7 @@ class RabbitMQBus:
 
     # ------------------------------------------------------------------ #
     async def publish(self, evt: Event) -> None:
-        if self._chan is None:                # pragma: no cover
+        if self._chan is None:  # pragma: no cover
             raise RuntimeError("RabbitMQBus.start() not called")
         await self._chan.default_exchange.publish(
             aio_pika.Message(
@@ -68,8 +69,8 @@ def get_rabbitmq_bus() -> RabbitMQBus:
     """Create / return the singleton RabbitMQBus."""
     global _BUS_SINGLETON
     if _BUS_SINGLETON is None:
-        amqp_url = os.getenv("EVENT_BROKER_URL")
+        amqp_url = os.getenv("EVENT_BROKER_URL") or os.getenv("AMQP_URL")
         if not amqp_url:
-            raise RuntimeError("EVENT_BROKER_URL is not set")
+            raise RuntimeError("EVENT_BROKER_URL/AMQP_URL is not set")
         _BUS_SINGLETON = RabbitMQBus(amqp_url)
     return _BUS_SINGLETON

--- a/video/eventbus/__init__.py
+++ b/video/eventbus/__init__.py
@@ -18,34 +18,49 @@ class _AMQPBus:
         self._conn = pika.BlockingConnection(pika.URLParameters(url))
         self._ch = self._conn.channel()
         self._exchange = exchange
-        self._ch.exchange_declare(exchange=exchange, exchange_type="topic", durable=True)
+        self._ch.exchange_declare(
+            exchange=exchange, exchange_type="topic", durable=True
+        )
 
     def publish(self, topic: str, payload: dict) -> None:
         body = json.dumps(payload).encode()
-        self._ch.basic_publish(self._exchange, topic, body, pika.BasicProperties(content_type="application/json"))
+        self._ch.basic_publish(
+            self._exchange,
+            topic,
+            body,
+            pika.BasicProperties(content_type="application/json"),
+        )
 
     def subscribe(self, topic: str, handler: Callable[[bytes], None]) -> None:
         q = self._ch.queue_declare("", exclusive=True)
         name = q.method.queue
         self._ch.queue_bind(name, self._exchange, topic)
+
         def _cb(ch, method, properties, body):
             handler(body)
+
         self._ch.basic_consume(name, _cb, auto_ack=True)
 
     def close(self) -> None:
         self._conn.close()
 
+
 _bus: Optional[_AMQPBus] = None
+
 
 def connect(url: str | None = None, exchange: str = "events") -> _AMQPBus:
     """Connect returns a singleton bus instance."""
     global _bus
     if _bus is None:
-        url = url or os.getenv("AMQP_URL", "amqp://guest:guest@localhost/")
+        url = (
+            url
+            or os.getenv("EVENT_BROKER_URL")
+            or os.getenv("AMQP_URL", "amqp://guest:guest@localhost/")
+        )
         exchange = exchange or os.getenv("AMQP_EXCHANGE", "events")
         _bus = _AMQPBus(url, exchange)
     return _bus
 
+
 def publish(topic: str, payload: dict) -> None:
     connect().publish(topic, payload)
-


### PR DESCRIPTION
## Summary
- scaffold overlay-hub service with basic endpoints
- add shared overlay client and registration hooks for agents
- expose JWKS/token endpoints in api-gateway and wire overlay-hub into infra

## Testing
- `go test ./host/services/shared/overlay -run .`
- `go test ./host/services/overlay-hub/cmd/overlay-hub -run .`
- `go test ./host/services/api-gateway/cmd -run .` *(fails: module download forbidden)*
- `go test ./host/services/capture-daemon -run overlay` *(fails: module download forbidden)*
- `go test ./host/services/camera-proxy -run overlay` *(fails: module download forbidden)*

## Checklist
- [x] Code is self-contained and idempotent.
- [x] No unnecessary new files or external dependencies.
- [x] Tests added or updated as appropriate.
- [x] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_68950ece7e74832697e5aabde4f33d0a