### PR TITLE
Refactor dashboard tools into typed React components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,6 +148,7 @@ go.sum
 !/docker/web-app/package.json
 
 !/docker/web-app/tsconfig.json
+!/docker/web-app/tsconfig.test.json
 
 !/docker/rabbitmq/definitions.json
 

--- a/docker/web-app/package.json
+++ b/docker/web-app/package.json
@@ -14,7 +14,7 @@
     "docker:build": "docker build -t thatdamtoolbox-web-app:dev .",
     "docker:run": "docker run --rm -p 3000:3000 thatdamtoolbox-web-app:dev",
     "docker:sh": "docker run -it --rm thatdamtoolbox-web-app:dev sh",
-    "test": "tsc src/state/selection.ts src/state/selection.test.ts --outDir .tmp-test --module commonjs --target es2019 --noEmit false && node --test .tmp-test/selection.test.js"
+    "test": "rm -rf .tmp-test && tsc -p tsconfig.test.json && node --test .tmp-test"
   },
   "dependencies": {
     "next": "14.0.4",

--- a/docker/web-app/src/app/dashboard/README.md
+++ b/docker/web-app/src/app/dashboard/README.md
@@ -1,6 +1,8 @@
 ## Dashboard Modules
 
-The dashboard auto-discovers its tools from `components/dashboardTools.ts`.
+The dashboard auto-discovers its tools from `components/dashboardTools.ts` and
+groups them using the `useIntelligentLayout` hook (`src/hooks/useIntelligentLayout.ts`).
+Tools are rendered in primary/secondary/tertiary sections based on activity and recency.
 
 | Route                           | Purpose            |
 |---------------------------------|--------------------|

--- a/docker/web-app/src/app/dashboard/ffmpeg/page.tsx
+++ b/docker/web-app/src/app/dashboard/ffmpeg/page.tsx
@@ -1,0 +1,5 @@
+import FFmpegConsole from '@/components/tools/FFmpegConsole'
+
+export default function FfmpegPage() {
+  return <FFmpegConsole />
+}

--- a/docker/web-app/src/app/dashboard/motion/page.tsx
+++ b/docker/web-app/src/app/dashboard/motion/page.tsx
@@ -1,8 +1,5 @@
+import MotionExtract from '@/components/tools/MotionExtract'
+
 export default function MotionPage() {
-  return (
-    <section className="p-8">
-      <h2 className="text-3xl font-bold mb-4">Motion Tool</h2>
-      <p>Analyze and extract motion data from videos.</p>
-    </section>
-  );
+  return <MotionExtract />
 }

--- a/docker/web-app/src/app/dashboard/page.tsx
+++ b/docker/web-app/src/app/dashboard/page.tsx
@@ -1,46 +1,40 @@
 // /docker/web-app/src/app/dashboard/page.tsx
 'use client';
 
-import useSWR from 'swr'
 import { dashboardTools } from '@/components/dashboardTools'
 import ToolCard from '@/components/ToolCard'
-
-interface ApiStats {
-  assets: number
-  countBytes: number
-}
+import AnalyticsCard from '@/components/tools/AnalyticsCard'
+import { useIntelligentLayout } from '@/hooks/useIntelligentLayout'
 
 export default function DashboardMain() {
-  const fetcher = (url: string) => fetch(url).then(r => r.json())
-  const { data } = useSWR<ApiStats>('/api/library/stats', fetcher, {
-    fallbackData: { assets: 0, countBytes: 0 },
-  })
+  const tools = Object.values(dashboardTools)
+  const { layoutGroups } = useIntelligentLayout(tools)
 
   return (
     <div className="max-w-5xl mx-auto px-4 py-6 space-y-6">
-      {/* ────── live stats card ────── */}
-      <section className="bg-white rounded-xl shadow-sm p-6">
-        <h2 className="font-bold text-lg mb-2">📊 Library Stats</h2>
-        <ul className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
-          <li>
-            <span className="font-semibold text-gray-700">{data?.assets}</span>
-            <br />assets
-          </li>
-          <li>
-            <span className="font-semibold text-gray-700">
-              {(data?.countBytes / 1_000_000_000).toFixed(1)} GB
-            </span>
-            <br />disk usage
-          </li>
-        </ul>
-      </section>
+      <AnalyticsCard />
 
-      {/* ────── existing tool grid ────── */}
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-        {dashboardTools.map(({ href }) => (
-          <ToolCard key={href} href={href} />
-        ))}
-      </div>
+      <section className="space-y-6">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+          {layoutGroups.primary.map(t => (
+            <ToolCard key={t.id} toolId={t.id} />
+          ))}
+        </div>
+        {layoutGroups.secondary.length > 0 && (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+            {layoutGroups.secondary.map(t => (
+              <ToolCard key={t.id} toolId={t.id} isRelated />
+            ))}
+          </div>
+        )}
+        {layoutGroups.tertiary.length > 0 && (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+            {layoutGroups.tertiary.map(t => (
+              <ToolCard key={t.id} toolId={t.id} />
+            ))}
+          </div>
+        )}
+      </section>
     </div>
   );
 }

--- a/docker/web-app/src/components/Cards.tsx
+++ b/docker/web-app/src/components/Cards.tsx
@@ -1,18 +1,33 @@
 // /docker/web-app/src/components/Cards.tsx
 'use client'
 import React, { useRef } from "react";
-import {
-  videoCardStyle,
-  videoStyle,
-  videoInfoStyle,
-  sceneThumbStyle,
-  uploadCardStyle,
-  hiddenInputStyle,
-  uploadButtonStyle,
-} from '@/styles/theme';
+
+// --- types ---
+export interface BatchCardProps {
+  batch: { id?: string; batch?: string; count?: number; items?: unknown[] };
+  onClick?: () => void;
+}
+export interface VideoCardProps {
+  data: {
+    artifact?: {
+      preview?: string;
+      width?: number;
+      height?: number;
+      path?: string;
+      duration?: number;
+      mime?: string;
+    };
+    scenes?: { url: string }[];
+    score?: number;
+  };
+}
+export interface UploadCardProps {
+  onUpload: (files: File[]) => void;
+  loading?: boolean;
+}
 
 // --- BatchCard ---
-export function BatchCard({ batch, onClick }) {
+export function BatchCard({ batch, onClick }: BatchCardProps) {
   const name = batch.batch ?? batch.id ?? "";
   const count = batch.count ?? (batch.items?.length ?? "");
   return (
@@ -23,26 +38,26 @@ export function BatchCard({ batch, onClick }) {
 }
 
 // --- VideoCard ---
-export function VideoCard({ data }) {
+export function VideoCard({ data }: VideoCardProps) {
   const { artifact, scenes, score } = data;
   return (
-    <div className="video-card" style={videoCardStyle}>
+    <div className="video-card m-2 border border-gray-800 p-3">
       <video
         src={artifact?.preview ?? ""}
         width={artifact?.width ?? 240}
         height={artifact?.height ?? 120}
         controls
-        style={videoStyle}
+        className="block mb-2 max-w-full"
       />
-      <div style={videoInfoStyle}>
+      <div className="text-sm mb-1">
         <b>{artifact?.path}</b> <br />
         {artifact?.duration}s • {artifact?.mime}
       </div>
-      {scenes?.length > 0 && (
+      {scenes && scenes.length > 0 && (
         <div>
           <small>Scenes: </small>
           {scenes.map((s, i) => (
-            <img key={i} src={s.url} alt="thumb" width={48} height={32} style={sceneThumbStyle} />
+            <img key={i} src={s.url} alt="thumb" width={48} height={32} className="mr-1 inline-block" />
           ))}
         </div>
       )}
@@ -52,26 +67,27 @@ export function VideoCard({ data }) {
 }
 
 // --- UploadCard ---
-export function UploadCard({ onUpload, loading }) {
-  const fileRef = useRef();
-  function handleFiles(e) {
-    onUpload([...e.target.files]);
-    e.target.value = null; // reset
+export function UploadCard({ onUpload, loading }: UploadCardProps) {
+  const fileRef = useRef<HTMLInputElement>(null);
+  function handleFiles(e: React.ChangeEvent<HTMLInputElement>) {
+    const files = e.target.files ? Array.from(e.target.files) : [];
+    onUpload(files);
+    e.target.value = '';
   }
   return (
-    <div style={uploadCardStyle}>
+    <div className="mt-6">
       <input
         type="file"
         multiple
         ref={fileRef}
-        style={hiddenInputStyle}
+        className="hidden"
         onChange={handleFiles}
         disabled={loading}
       />
       <button
         disabled={loading}
         onClick={() => fileRef.current?.click()}
-        style={uploadButtonStyle}
+        className="mr-2"
       >
         ⬆️ Upload
       </button>

--- a/docker/web-app/src/components/Sidebar.tsx
+++ b/docker/web-app/src/components/Sidebar.tsx
@@ -23,9 +23,9 @@ export default function Sidebar() {
       </button>
 
       <nav className="flex flex-col gap-1 px-2">
-        {dashboardTools.map(({ href, title, icon: Icon }) => (
+        {Object.values(dashboardTools).map(({ href, title, icon: Icon, id }) => (
           <Link
-            key={href}
+            key={id}
             href={href}
             className="flex items-center gap-3 p-2 rounded-md hover:bg-white/40"
           >

--- a/docker/web-app/src/components/ToolCard.tsx
+++ b/docker/web-app/src/components/ToolCard.tsx
@@ -3,25 +3,25 @@
 import Link from 'next/link';
 import { dashboardTools } from './dashboardTools';
 import clsx from 'clsx';
-import { sizeClasses, iconClasses, titleClasses } from '@/styles/theme';
+import { sizeClasses, iconClasses, titleClasses } from '../styles/theme';
 
 interface ToolCardProps {
-  href: string;
+  toolId: string;
   size?: 'small' | 'medium' | 'large';
   isRelated?: boolean;
   onFocus?: (toolId: string) => void;
 }
 
 export default function ToolCard({
-  href,
+  toolId,
   size = 'medium',
   isRelated = false,
   onFocus,
 }: ToolCardProps) {
-  const tool = dashboardTools.find((t) => t.href === href);
+  const tool = dashboardTools[toolId];
   if (!tool) return null;
 
-  const { id, title, icon: Icon, color } = tool;
+  const { id, href, title, icon: Icon, color } = tool;
 
   // Sizing and style classes
 

--- a/docker/web-app/src/components/__tests__/AnalyticsCard.test.tsx
+++ b/docker/web-app/src/components/__tests__/AnalyticsCard.test.tsx
@@ -1,0 +1,10 @@
+import assert from 'node:assert'
+import test from 'node:test'
+import React from 'react'
+import { renderToString } from 'react-dom/server'
+import AnalyticsCard from '../tools/AnalyticsCard'
+
+test('AnalyticsCard renders heading', () => {
+  const html = renderToString(<AnalyticsCard />)
+  assert.ok(html.includes('Library Stats'))
+})

--- a/docker/web-app/src/components/__tests__/Cards.test.tsx
+++ b/docker/web-app/src/components/__tests__/Cards.test.tsx
@@ -1,0 +1,26 @@
+import assert from 'node:assert'
+import test from 'node:test'
+import React from 'react'
+import { renderToString } from 'react-dom/server'
+import { BatchCard, VideoCard, UploadCard } from '../Cards'
+
+test('BatchCard renders', () => {
+  const html = renderToString(
+    <BatchCard batch={{ id: '1', count: 2 }} onClick={() => {}} />
+  )
+  assert.ok(html.includes('📁'))
+})
+
+test('VideoCard renders', () => {
+  const html = renderToString(
+    <VideoCard data={{ artifact: { path: 'a', preview: '' } }} />
+  )
+  assert.ok(html.includes('video-card'))
+})
+
+test('UploadCard renders', () => {
+  const html = renderToString(
+    <UploadCard onUpload={() => {}} />
+  )
+  assert.ok(html.includes('Upload'))
+})

--- a/docker/web-app/src/components/__tests__/FFmpegConsole.test.tsx
+++ b/docker/web-app/src/components/__tests__/FFmpegConsole.test.tsx
@@ -1,0 +1,10 @@
+import assert from 'node:assert'
+import test from 'node:test'
+import React from 'react'
+import { renderToString } from 'react-dom/server'
+import FFmpegConsole from '../tools/FFmpegConsole'
+
+test('FFmpegConsole renders run button', () => {
+  const html = renderToString(<FFmpegConsole />)
+  assert.ok(html.includes('Run'))
+})

--- a/docker/web-app/src/components/__tests__/MotionExtract.test.tsx
+++ b/docker/web-app/src/components/__tests__/MotionExtract.test.tsx
@@ -1,0 +1,10 @@
+import assert from 'node:assert'
+import test from 'node:test'
+import React from 'react'
+import { renderToString } from 'react-dom/server'
+import MotionExtract from '../tools/MotionExtract'
+
+test('MotionExtract renders heading', () => {
+  const html = renderToString(<MotionExtract />)
+  assert.ok(html.includes('Motion Extract'))
+})

--- a/docker/web-app/src/components/__tests__/ToolCard.test.tsx
+++ b/docker/web-app/src/components/__tests__/ToolCard.test.tsx
@@ -1,0 +1,17 @@
+import assert from 'node:assert'
+import test from 'node:test'
+import React from 'react'
+import { renderToString } from 'react-dom/server'
+import ToolCard from '../ToolCard'
+import { dashboardTools } from '../dashboardTools'
+
+test('ToolCard renders by id', () => {
+  const id = Object.keys(dashboardTools)[0]
+  const html = renderToString(<ToolCard toolId={id} />)
+  assert.ok(html.includes(dashboardTools[id].title))
+})
+
+test('ToolCard returns empty for missing id', () => {
+  const html = renderToString(<ToolCard toolId="missing" />)
+  assert.equal(html, '')
+})

--- a/docker/web-app/src/components/dashboardTools.tsx
+++ b/docker/web-app/src/components/dashboardTools.tsx
@@ -1,13 +1,5 @@
-import React, { useState, useMemo } from 'react';
-import { dashboardColorClasses } from '@/styles/theme';
-import {
-  Camera,
-  FolderOpen,
-  Video,
-  Activity,
-  UserCheck,
-  Eye,
-} from 'lucide-react';
+import { dashboardColorClasses } from '../styles/theme';
+import { Camera, FolderOpen, Video, Activity, UserCheck, Eye } from 'lucide-react';
 
 /** 
  * A dashboard "tool" with rich metadata for intelligent layout 
@@ -27,8 +19,8 @@ export interface DashboardTool {
 /** 
  * Your canonical list of dashboard tools, now with context, recency, status, etc. 
  */
-export const dashboardTools: DashboardTool[] = [
-  {
+export const dashboardTools: Record<string, DashboardTool> = {
+  'camera-monitor': {
     id: 'camera-monitor',
     href: '/dashboard/camera-monitor',
     title: 'Camera Monitor',
@@ -39,7 +31,7 @@ export const dashboardTools: DashboardTool[] = [
     lastUsed: '2024-01-20T10:30:00Z',
     status: 'active',
   },
-  {
+  'dam-explorer': {
     id: 'dam-explorer',
     href: '/dashboard/dam-explorer',
     title: 'DAM Explorer',
@@ -50,7 +42,7 @@ export const dashboardTools: DashboardTool[] = [
     lastUsed: '2024-01-20T09:15:00Z',
     status: 'idle',
   },
-  {
+  motion: {
     id: 'motion',
     href: '/dashboard/motion',
     title: 'Motion Tool',
@@ -61,7 +53,7 @@ export const dashboardTools: DashboardTool[] = [
     lastUsed: '2024-01-19T16:20:00Z',
     status: 'idle',
   },
-  {
+  live: {
     id: 'live',
     href: '/dashboard/live',
     title: 'Live Monitor',
@@ -72,7 +64,7 @@ export const dashboardTools: DashboardTool[] = [
     lastUsed: '2024-01-20T08:45:00Z',
     status: 'processing',
   },
-  {
+  witness: {
     id: 'witness',
     href: '/dashboard/witness',
     title: 'Witness Tool',
@@ -83,7 +75,18 @@ export const dashboardTools: DashboardTool[] = [
     lastUsed: '2024-01-18T14:30:00Z',
     status: 'idle',
   },
-  {
+  ffmpeg: {
+    id: 'ffmpeg',
+    href: '/dashboard/ffmpeg',
+    title: 'FFmpeg Console',
+    icon: Activity,
+    color: dashboardColorClasses['motion'],
+    context: 'analysis',
+    relatedTools: ['motion'],
+    lastUsed: '2024-01-16T12:00:00Z',
+    status: 'idle',
+  },
+  explorer: {
     id: 'explorer',
     href: '/dashboard/explorer',
     title: 'File Explorer',
@@ -94,45 +97,4 @@ export const dashboardTools: DashboardTool[] = [
     lastUsed: '2024-01-17T11:20:00Z',
     status: 'idle',
   },
-];
-
-/**
- * Hook to group tools into primary/secondary/tertiary based on status & recency.
- */
-export function useIntelligentLayout(tools: DashboardTool[]) {
-  const [focusedTool, setFocusedTool] = useState<string | null>(null);
-  const [userIntent, setUserIntent] = useState<'browse'|'work'|'analyze'>('browse');
-
-  const layoutGroups = useMemo(() => {
-    type Groups = {
-      primary: DashboardTool[];
-      secondary: DashboardTool[];
-      tertiary: DashboardTool[];
-    };
-
-    // 1) sort by active first, then by lastUsed desc
-    const sorted = [...tools].sort((a, b) => {
-      if (a.status === 'active' && b.status !== 'active') return -1;
-      if (b.status === 'active' && a.status !== 'active') return 1;
-      return new Date(b.lastUsed).getTime() - new Date(a.lastUsed).getTime();
-    });
-
-    // 2) pick top-2 as primary
-    const primary = sorted.slice(0, 2);
-
-    // 3) collect all related IDs
-    const primaryIds = new Set(primary.map(t => t.id));
-    const relatedIds = new Set<string>();
-    primary.forEach(t => t.relatedTools.forEach(r => relatedIds.add(r)));
-
-    // 4) secondary = those in relatedIds but not primary
-    const secondary = sorted.filter(t => !primaryIds.has(t.id) && relatedIds.has(t.id));
-
-    // 5) tertiary = everything else
-    const tertiary = sorted.filter(t => !primaryIds.has(t.id) && !relatedIds.has(t.id));
-
-    return { primary, secondary, tertiary };
-  }, [tools]);
-
-  return { layoutGroups, focusedTool, setFocusedTool, userIntent, setUserIntent };
-}
+};

--- a/docker/web-app/src/components/tools/AnalyticsCard.tsx
+++ b/docker/web-app/src/components/tools/AnalyticsCard.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+interface ApiStats {
+  assets: number
+  countBytes: number
+}
+
+/** Dashboard card showing library statistics */
+export default function AnalyticsCard() {
+  const [data, setData] = useState<ApiStats>({ assets: 0, countBytes: 0 })
+
+  useEffect(() => {
+    fetch('/api/library/stats')
+      .then(r => r.json())
+      .then(setData)
+      .catch(() => {})
+  }, [])
+
+  return (
+    <section className="bg-white rounded-xl shadow-sm p-6">
+      <h2 className="font-bold text-lg mb-2">📊 Library Stats</h2>
+      <ul className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
+        <li>
+          <span className="font-semibold text-gray-700">{data.assets}</span>
+          <br />assets
+        </li>
+        <li>
+          <span className="font-semibold text-gray-700">
+            {(data.countBytes / 1_000_000_000).toFixed(1)} GB
+          </span>
+          <br />disk usage
+        </li>
+      </ul>
+    </section>
+  )
+}

--- a/docker/web-app/src/components/tools/FFmpegConsole.tsx
+++ b/docker/web-app/src/components/tools/FFmpegConsole.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+import { useState } from 'react'
+import { videoApi } from '../../lib/videoApi'
+
+/**
+ * Simple FFmpeg console ported from legacy Jinja template.
+ * Allows entering a command string and displays server output.
+ */
+export default function FFmpegConsole() {
+  const [command, setCommand] = useState('')
+  const [output, setOutput] = useState('')
+  const [running, setRunning] = useState(false)
+
+  async function run() {
+    if (!command.trim()) return
+    setRunning(true)
+    try {
+      const res = await videoApi.ffmpegRun({ command })
+      setOutput(res.output)
+    } catch (err: any) {
+      setOutput(String(err))
+    } finally {
+      setRunning(false)
+    }
+  }
+
+  return (
+    <section className="p-6 space-y-4">
+      <h2 className="text-xl font-bold">FFmpeg Console</h2>
+      <textarea
+        className="w-full border rounded p-2"
+        rows={4}
+        placeholder="ffmpeg command here"
+        value={command}
+        onChange={(e) => setCommand(e.target.value)}
+      />
+      <button
+        className="px-4 py-2 bg-blue-600 text-white rounded disabled:opacity-50"
+        onClick={run}
+        disabled={running}
+      >
+        {running ? 'Running…' : 'Run'}
+      </button>
+      {output && (
+        <pre className="bg-gray-100 p-2 rounded text-sm whitespace-pre-wrap">{output}</pre>
+      )}
+    </section>
+  )
+}

--- a/docker/web-app/src/components/tools/MotionExtract.tsx
+++ b/docker/web-app/src/components/tools/MotionExtract.tsx
@@ -1,0 +1,44 @@
+'use client'
+
+import { useState } from 'react'
+import { videoApi } from '../../lib/videoApi'
+
+/**
+ * Minimal motion extraction tool.
+ * Allows selecting a file path and triggers extraction via API.
+ */
+export default function MotionExtract() {
+  const [path, setPath] = useState('')
+  const [status, setStatus] = useState('idle')
+
+  async function extract() {
+    if (!path) return
+    setStatus('working')
+    try {
+      const job = await videoApi.motionExtract({ path })
+      setStatus(job.status)
+    } catch (err: any) {
+      setStatus('error')
+    }
+  }
+
+  return (
+    <section className="p-6 space-y-4">
+      <h2 className="text-xl font-bold">Motion Extract</h2>
+      <input
+        className="border rounded p-2 w-full"
+        placeholder="/path/to/video.mp4"
+        value={path}
+        onChange={(e) => setPath(e.target.value)}
+      />
+      <button
+        className="px-4 py-2 bg-blue-600 text-white rounded disabled:opacity-50"
+        onClick={extract}
+        disabled={!path || status === 'working'}
+      >
+        Extract
+      </button>
+      <p className="text-sm text-gray-700">Status: {status}</p>
+    </section>
+  )
+}

--- a/docker/web-app/src/hooks/__tests__/useIntelligentLayout.test.tsx
+++ b/docker/web-app/src/hooks/__tests__/useIntelligentLayout.test.tsx
@@ -1,0 +1,38 @@
+import assert from 'node:assert'
+import test from 'node:test'
+import React from 'react'
+import { renderToString } from 'react-dom/server'
+import { computeLayoutGroups, useIntelligentLayout } from '../useIntelligentLayout'
+import type { DashboardTool } from '@/components/dashboardTools'
+
+const sample: DashboardTool[] = [
+  {
+    id: 'a', href: '', title: 'A', icon: () => null, color: '', context: '',
+    relatedTools: ['b'], lastUsed: '2024-01-20T00:00:00Z', status: 'active'
+  },
+  {
+    id: 'b', href: '', title: 'B', icon: () => null, color: '', context: '',
+    relatedTools: [], lastUsed: '2024-01-18T00:00:00Z', status: 'idle'
+  },
+  {
+    id: 'c', href: '', title: 'C', icon: () => null, color: '', context: '',
+    relatedTools: [], lastUsed: '2024-01-19T00:00:00Z', status: 'idle'
+  }
+]
+
+test('groups tools intelligently', () => {
+  const groups = computeLayoutGroups(sample)
+  assert.equal(groups.primary.length, 2)
+  assert.ok(groups.secondary.find(t => t.id === 'b'))
+})
+
+test('provides focus setter', () => {
+  let hook: any
+  function Test() {
+    hook = useIntelligentLayout(sample)
+    return null
+  }
+  renderToString(<Test />)
+  assert.equal(hook.focusedTool, null)
+  assert.equal(typeof hook.setFocusedTool, 'function')
+})

--- a/docker/web-app/src/hooks/useIntelligentLayout.ts
+++ b/docker/web-app/src/hooks/useIntelligentLayout.ts
@@ -1,0 +1,26 @@
+import { useState, useMemo } from 'react'
+import type { DashboardTool } from '../components/dashboardTools'
+
+/** Compute groups of tools based on status and recency */
+export function computeLayoutGroups(tools: DashboardTool[]) {
+  const sorted = [...tools].sort((a, b) => {
+    if (a.status === 'active' && b.status !== 'active') return -1
+    if (b.status === 'active' && a.status !== 'active') return 1
+    return new Date(b.lastUsed).getTime() - new Date(a.lastUsed).getTime()
+  })
+  const primary = sorted.slice(0, 2)
+  const primaryIds = new Set(primary.map(t => t.id))
+  const relatedIds = new Set<string>()
+  primary.forEach(t => t.relatedTools.forEach(r => relatedIds.add(r)))
+  const secondary = sorted.filter(t => !primaryIds.has(t.id) && relatedIds.has(t.id))
+  const tertiary = sorted.filter(t => !primaryIds.has(t.id) && !relatedIds.has(t.id))
+  return { primary, secondary, tertiary }
+}
+
+/** Hook wrapper exposing focus state */
+export function useIntelligentLayout(tools: DashboardTool[]) {
+  const [focusedTool, setFocusedTool] = useState<string | null>(null)
+  const [userIntent, setUserIntent] = useState<'browse' | 'work' | 'analyze'>('browse')
+  const layoutGroups = useMemo(() => computeLayoutGroups(tools), [tools])
+  return { layoutGroups, focusedTool, setFocusedTool, userIntent, setUserIntent }
+}

--- a/docker/web-app/src/lib/videoApi.ts
+++ b/docker/web-app/src/lib/videoApi.ts
@@ -30,6 +30,10 @@ export const videoApi = {
   motionExtract: (payload: MotionExtractPayload) =>
     postJson<MotionJob>('/motion/extract', payload),
 
+  /* ffmpeg console */
+  ffmpegRun: (payload: { command: string; output?: string }) =>
+    postJson<{ output: string }>('/ffmpeg/run', payload),
+
   /* hardware capture helpers */
   listDevices: () => getJson<Device[]>('/hwcapture/devices'),
   witnessStart: (req: WitnessReq) => postJson<{}>('/hwcapture/witness_record', req),

--- a/docker/web-app/tsconfig.test.json
+++ b/docker/web-app/tsconfig.test.json
@@ -1,0 +1,21 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": ".tmp-test",
+    "module": "commonjs",
+    "target": "es2019",
+    "jsx": "react-jsx"
+  },
+  "include": [
+    "src/components/__tests__/**/*.tsx",
+    "src/hooks/__tests__/**/*.tsx",
+    "src/components/tools/FFmpegConsole.tsx",
+    "src/components/tools/AnalyticsCard.tsx",
+    "src/components/tools/MotionExtract.tsx",
+    "src/components/ToolCard.tsx",
+    "src/components/dashboardTools.tsx",
+    "src/components/Cards.tsx",
+    "src/hooks/useIntelligentLayout.ts"
+  ]
+}


### PR DESCRIPTION
## Summary
- port legacy FFmpeg console, analytics stats, and motion extract cards to reusable React components
- stabilize dashboard tool lookup via id and add intelligent layout hook
- type card primitives and add Node test suite for new components

## Testing
- `cd docker/web-app && npm test`

## Checklist
- [x] Code is self-contained and idempotent.
- [x] No unnecessary new files or external dependencies.
- [x] Tests added or updated as appropriate.
- [x] Docs updated where needed.

------
https://chatgpt.com/codex/tasks/task_e_6895f87eb8cc8326bfeedb7ad11b1bc4