### PR TITLE
feat: centralize design tokens and unify UI

### DIFF
--- a/docker/web-app/src/components/DAMExplorer.tsx
+++ b/docker/web-app/src/components/DAMExplorer.tsx
@@ -82,9 +82,13 @@ const AssetThumbnail: React.FC<{ asset: Asset }> = ({ asset }) => {
   const sizeMb = (asset.size / 1_000_000).toFixed(1)
 
   return (
-    <SelectableItem id={asset.id} actions={actions} className="relative group cursor-pointer border-2 rounded-lg p-3 transition-all duration-200 hover:shadow-lg border-gray-200 bg-white">
+    <SelectableItem
+      id={asset.id}
+      actions={actions}
+      className="relative group cursor-pointer p-3 transition-all duration-200 hover:shadow-md border-color-border bg-surface rounded-lg border"
+    >
       {/* Thumbnail or Icon */}
-      <div className="aspect-square mb-2 bg-gray-100 rounded-md flex items-center justify-center overflow-hidden">
+      <div className="aspect-square mb-2 bg-surface rounded-md flex items-center justify-center overflow-hidden">
         {asset.thumbnail ? (
           <img
             src={asset.thumbnail}
@@ -92,7 +96,7 @@ const AssetThumbnail: React.FC<{ asset: Asset }> = ({ asset }) => {
             className="w-full h-full object-cover"
           />
         ) : (
-          <div className="text-gray-400">
+          <div className="text-color-muted">
             {getIcon(asset.type ?? asset.kind)}
           </div>
         )}
@@ -103,7 +107,7 @@ const AssetThumbnail: React.FC<{ asset: Asset }> = ({ asset }) => {
         <h4 className="font-medium text-sm truncate" title={asset.name}>
           {asset.name}
         </h4>
-        <div className="flex items-center justify-between text-xs text-gray-500">
+        <div className="flex items-center justify-between text-xs text-color-muted">
           <span>{sizeMb} MB</span>
           <span
             className={`px-2 py-1 rounded-full text-xs ${getStatusColor(asset.status)}`}
@@ -137,8 +141,8 @@ const FolderTree: React.FC<{
     return (
       <div key={folder.path} style={folderIndentStyle(level)}>
         <div
-          className={`flex items-center space-x-2 p-2 rounded cursor-pointer hover:bg-gray-100 ${
-            currentPath === folder.path ? 'bg-blue-50 text-blue-700' : ''
+          className={`flex items-center space-x-2 p-2 rounded cursor-pointer hover:bg-surface ${
+            currentPath === folder.path ? 'bg-color-primary-bg text-theme-primary' : ''
           }`}
           onClick={() => onPathChange(folder.path)}
         >
@@ -147,7 +151,7 @@ const FolderTree: React.FC<{
               e.stopPropagation()
               toggle(folder.path)
             }}
-            className="p-1 hover:bg-gray-200 rounded"
+            className="p-1 hover:bg-surface rounded"
           >
             {folder.children.length > 0 ? (
               isOpen ? (
@@ -159,7 +163,7 @@ const FolderTree: React.FC<{
               <div className="w-4 h-4" />
             )}
           </button>
-          <Folder className="w-4 h-4 text-gray-600" />
+          <Folder className="w-4 h-4 text-color-muted" />
           <span className="text-sm">{folder.name}</span>
         </div>
         {isOpen &&

--- a/docker/web-app/src/components/SearchBarExtension.tsx
+++ b/docker/web-app/src/components/SearchBarExtension.tsx
@@ -201,9 +201,9 @@ const SearchBarExtension: React.FC<SearchBarProps> = ({
   return (
     <div ref={searchRef} className={`relative ${className}`}>
       <div className="relative">
-        <div className="flex items-center bg-white border border-gray-300 rounded-lg shadow-sm hover:shadow-md transition-shadow">
+        <div className="flex items-center bg-surface border border-color-border rounded-lg shadow-sm hover:shadow-md transition-shadow">
           <div className="pl-4">
-            <Search className="w-5 h-5 text-gray-400" />
+            <Search className="w-5 h-5 text-color-muted" />
           </div>
           <input
             ref={inputRef}
@@ -221,8 +221,8 @@ const SearchBarExtension: React.FC<SearchBarProps> = ({
                 onClick={() => setShowFilterPanel(!showFilterPanel)}
                 className={`p-2 rounded-md transition-colors ${
                   showFilterPanel || hasActiveFilters
-                    ? 'bg-blue-100 text-blue-600'
-                    : 'text-gray-400 hover:text-gray-600 hover:bg-gray-100'
+                    ? 'bg-color-primary-bg text-theme-primary'
+                    : 'text-color-muted hover:text-theme-primary hover:bg-surface'
                 }`}
                 title="Filters"
               >
@@ -234,8 +234,8 @@ const SearchBarExtension: React.FC<SearchBarProps> = ({
                 onClick={() => setShowVectorPanel(!showVectorPanel)}
                 className={`p-2 rounded-md transition-colors ${
                   showVectorPanel
-                    ? 'bg-purple-100 text-purple-600'
-                    : 'text-gray-400 hover:text-gray-600 hover:bg-gray-100'
+                    ? 'bg-color-accent-bg text-theme-primary'
+                    : 'text-color-muted hover:text-theme-primary hover:bg-surface'
                 }`}
                 title="AI Search"
               >
@@ -244,7 +244,7 @@ const SearchBarExtension: React.FC<SearchBarProps> = ({
             )}
             {(isSearching || loading) && (
               <div className="p-2">
-                <Loader2 className="w-4 h-4 animate-spin text-blue-500" />
+                <Loader2 className="w-4 h-4 animate-spin text-theme-primary" />
               </div>
             )}
           </div>
@@ -257,13 +257,13 @@ const SearchBarExtension: React.FC<SearchBarProps> = ({
               return (
                 <span
                   key={key}
-                  className="inline-flex items-center px-2 py-1 bg-blue-100 text-blue-800 text-xs rounded-md"
+                  className="inline-flex items-center px-2 py-1 bg-color-primary-bg text-theme-primary text-xs rounded-md"
                 >
                   <span className="capitalize mr-1">{key}:</span>
                   <span className="font-medium">{displayValue}</span>
                   <button
                     onClick={() => updateFilter(key, Array.isArray(value) ? [] : '')}
-                    className="ml-1 hover:text-blue-600"
+                    className="ml-1 hover:text-theme-primary"
                   >
                     <X className="w-3 h-3" />
                   </button>
@@ -272,7 +272,7 @@ const SearchBarExtension: React.FC<SearchBarProps> = ({
             })}
             <button
               onClick={clearFilters}
-              className="text-xs text-gray-500 hover:text-gray-700 underline"
+              className="text-xs text-color-muted hover:text-theme-primary underline"
             >
               Clear all
             </button>
@@ -280,10 +280,10 @@ const SearchBarExtension: React.FC<SearchBarProps> = ({
         )}
       </div>
       {showFilterPanel && (
-        <div className="absolute top-full left-0 right-0 mt-2 bg-white border border-gray-200 rounded-lg shadow-lg z-50 p-4">
+        <div className="absolute top-full left-0 right-0 mt-2 bg-surface border border-color-border rounded-lg shadow-lg z-50 p-4">
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
             <div className="space-y-2">
-              <label className="block text-sm font-medium text-gray-700">
+              <label className="block text-sm font-medium">
                 <Calendar className="w-4 h-4 inline mr-1" />
                 Date Range
               </label>
@@ -291,26 +291,26 @@ const SearchBarExtension: React.FC<SearchBarProps> = ({
                 type="date"
                 value={filters.dateFrom || ''}
                 onChange={e => updateFilter('dateFrom', e.target.value)}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                className="input w-full text-sm focus:ring-2 focus:ring-theme-primary"
                 placeholder="From"
               />
               <input
                 type="date"
                 value={filters.dateTo || ''}
                 onChange={e => updateFilter('dateTo', e.target.value)}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                className="input w-full text-sm focus:ring-2 focus:ring-theme-primary"
                 placeholder="To"
               />
             </div>
             <div className="space-y-2">
-              <label className="block text-sm font-medium text-gray-700">
+              <label className="block text-sm font-medium">
                 <FileType className="w-4 h-4 inline mr-1" />
                 File Type
               </label>
               <select
                 value={filters.fileType || ''}
                 onChange={e => updateFilter('fileType', e.target.value)}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                className="input w-full text-sm focus:ring-2 focus:ring-theme-primary"
               >
                 <option value="">All Types</option>
                 {availableFileTypes.map(type => (
@@ -321,14 +321,14 @@ const SearchBarExtension: React.FC<SearchBarProps> = ({
               </select>
             </div>
             <div className="space-y-2">
-              <label className="block text-sm font-medium text-gray-700">
+              <label className="block text-sm font-medium">
                 <Clock className="w-4 h-4 inline mr-1" />
                 Duration
               </label>
               <select
                 value={filters.duration || ''}
                 onChange={e => updateFilter('duration', e.target.value)}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                className="input w-full text-sm focus:ring-2 focus:ring-theme-primary"
               >
                 <option value="">Any Duration</option>
                 <option value="0-30">0–30 seconds</option>
@@ -340,7 +340,7 @@ const SearchBarExtension: React.FC<SearchBarProps> = ({
           </div>
           {availableTags.length > 0 && (
             <div className="mt-4 space-y-2">
-              <label className="block text-sm font-medium text-gray-700">
+              <label className="block text-sm font-medium">
                 <Tag className="w-4 h-4 inline mr-1" />
                 Tags
               </label>
@@ -357,23 +357,23 @@ const SearchBarExtension: React.FC<SearchBarProps> = ({
                           : currentTags.filter(t => t !== tag)
                         updateFilter('tags', newTags)
                       }}
-                      className="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                      className="rounded border-color-border text-theme-primary focus:ring-theme-primary"
                     />
-                    <span className="text-gray-700">{tag}</span>
+                    <span>{tag}</span>
                   </label>
                 ))}
               </div>
             </div>
           )}
           {customFilters && (
-            <div className="mt-4 pt-4 border-t border-gray-200">{customFilters}</div>
+            <div className="mt-4 pt-4 border-t border-color-border">{customFilters}</div>
           )}
         </div>
       )}
       {showVectorSearch && showVectorPanel && (
-        <div className="absolute top-full left-0 right-0 mt-2 bg-white border border-gray-200 rounded-lg shadow-lg z-50 p-4">
+        <div className="absolute top-full left-0 right-0 mt-2 bg-surface border border-color-border rounded-lg shadow-lg z-50 p-4">
           <div className="space-y-3">
-            <label className="block text-sm font-medium text-gray-700">
+            <label className="block text-sm font-medium">
               <Sparkles className="w-4 h-4 inline mr-1" />
               Describe what you're looking for
             </label>
@@ -382,12 +382,12 @@ const SearchBarExtension: React.FC<SearchBarProps> = ({
               onChange={e => setVectorQuery(e.target.value)}
               rows={3}
               placeholder="e.g., 'sunset over ocean', 'business meeting', 'happy children playing'"
-              className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-2 focus:ring-purple-500 focus:border-purple-500 resize-none"
+              className="input w-full text-sm focus:ring-2 focus:ring-theme-primary resize-none"
             />
             <button
               onClick={handleVectorSearch}
               disabled={!vectorQuery.trim() || isSearching}
-              className="w-full flex items-center justify-center space-x-2 px-4 py-2 bg-purple-600 text-white rounded-md hover:bg-purple-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              className="w-full flex items-center justify-center space-x-2 px-4 py-2 bg-theme-primary text-white rounded-md hover:bg-theme-primary/80 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
             >
               {isSearching ? (
                 <Loader2 className="w-4 h-4 animate-spin" />
@@ -402,7 +402,7 @@ const SearchBarExtension: React.FC<SearchBarProps> = ({
       {showResults && (
         <div
           ref={resultsRef}
-          className="absolute top-full left-0 right-0 mt-2 bg-white border border-gray-200 rounded-lg shadow-lg z-40 max-h-96 overflow-y-auto"
+          className="absolute top-full left-0 right-0 mt-2 bg-surface border border-color-border rounded-lg shadow-lg z-40 max-h-96 overflow-y-auto"
         >
           {results.length > 0 ? (
             <div className="py-2">
@@ -410,10 +410,10 @@ const SearchBarExtension: React.FC<SearchBarProps> = ({
                 <div
                   key={result.id}
                   onClick={() => handleResultSelect(result)}
-                  className={`px-4 py-3 cursor-pointer border-b border-gray-100 last:border-b-0 transition-colors ${
+                  className={`px-4 py-3 cursor-pointer border-b border-color-border last:border-b-0 transition-colors ${
                     index === selectedIndex
-                      ? 'bg-blue-50 border-blue-200'
-                      : 'hover:bg-gray-50'
+                      ? 'bg-color-primary-bg border-theme-primary'
+                      : 'hover:bg-surface'
                   }`}
                 >
                   <div className="flex items-center space-x-3">
@@ -428,28 +428,28 @@ const SearchBarExtension: React.FC<SearchBarProps> = ({
                     )}
                     <div className="flex-1 min-w-0">
                       <div className="flex items-center justify-between">
-                        <h4 className="text-sm font-medium text-gray-900 truncate">
+                        <h4 className="text-sm font-medium truncate">
                           {result.title}
                         </h4>
                         {result.score && (
-                          <span className="text-xs text-gray-500 ml-2">
+                          <span className="text-xs text-color-muted ml-2">
                             {(result.score * 100).toFixed(0)}%
                           </span>
                         )}
                       </div>
                       {result.subtitle && (
-                        <p className="text-sm text-gray-600 truncate mt-1">
+                        <p className="text-sm text-color-muted truncate mt-1">
                           {result.subtitle}
                         </p>
                       )}
                       <div className="flex items-center space-x-2 mt-1">
                         {result.type && (
-                          <span className="inline-block px-2 py-1 text-xs bg-gray-100 text-gray-700 rounded">
+                          <span className="inline-block px-2 py-1 text-xs bg-surface text-color-muted rounded">
                             {result.type}
                           </span>
                         )}
                         {result.path && (
-                          <span className="text-xs text-gray-500 truncate">
+                          <span className="text-xs text-color-muted truncate">
                             {result.path}
                           </span>
                         )}
@@ -460,11 +460,11 @@ const SearchBarExtension: React.FC<SearchBarProps> = ({
               ))}
             </div>
           ) : (
-            <div className="px-4 py-8 text-center text-gray-500">
-              <Search className="w-8 h-8 mx-auto mb-2 text-gray-300" />
+            <div className="px-4 py-8 text-center text-color-muted">
+              <Search className="w-8 h-8 mx-auto mb-2 text-color-muted" />
               <p className="text-sm">No results found</p>
               {query && (
-                <p className="text-xs text-gray-400 mt-1">
+                <p className="text-xs text-color-muted mt-1">
                   Try adjusting your search terms or filters
                 </p>
               )}

--- a/docker/web-app/src/components/Sidebar.tsx
+++ b/docker/web-app/src/components/Sidebar.tsx
@@ -1,38 +1,47 @@
 // /docker/web-app/src/components/Sidebar.tsx
 'use client';
 import Link from 'next/link'
+import { usePathname } from 'next/navigation'
 import { dashboardTools } from './dashboardTools'
 import clsx from 'clsx'
 import { useSidebar } from '@/hooks/useSidebar'
 
 export default function Sidebar() {
   const { collapsed, setCollapsed } = useSidebar()
+  const pathname = usePathname()
 
   return (
     <aside
-      className={clsx(
-        'transition-all duration-300 bg-white/60 backdrop-blur border-r border-glass-border shadow-lg',
-        collapsed ? 'w-16' : 'w-64',
-      )}
-    >
+        className={clsx(
+          'transition-all duration-300 backdrop-blur shadow-lg border-r border-color-border',
+          'bg-surface',
+          collapsed ? 'w-16' : 'w-64',
+        )}
+      >
       <button
         onClick={() => setCollapsed(!collapsed)}
-        className="p-3 w-full text-left text-sm font-semibold hover:bg-white/30"
+        className="p-3 w-full text-left text-sm font-semibold hover:bg-surface"
       >
         {collapsed ? '▶' : 'Collapse ◀'}
       </button>
 
       <nav className="flex flex-col gap-1 px-2">
-        {Object.values(dashboardTools).map(({ href, title, icon: Icon, id }) => (
-          <Link
-            key={id}
-            href={href}
-            className="flex items-center gap-3 p-2 rounded-md hover:bg-white/40"
-          >
-            <Icon className="text-lg shrink-0" />
-            {!collapsed && <span>{title}</span>}
-          </Link>
-        ))}
+        {Object.values(dashboardTools).map(({ href, title, icon: Icon, id }) => {
+          const active = pathname.startsWith(href)
+          return (
+            <Link
+              key={id}
+              href={href}
+              className={clsx(
+                'flex items-center gap-3 p-2 rounded-md hover:bg-surface',
+                active && 'bg-color-primary-bg text-theme-primary font-semibold'
+              )}
+            >
+              <Icon className="text-lg shrink-0" />
+              {!collapsed && <span>{title}</span>}
+            </Link>
+          )
+        })}
       </nav>
     </aside>
   );

--- a/docker/web-app/src/components/ToolCard.tsx
+++ b/docker/web-app/src/components/ToolCard.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link';
 import { dashboardTools } from './dashboardTools';
 import clsx from 'clsx';
-import { sizeClasses, iconClasses, titleClasses } from '../styles/theme';
+import { sizeClasses, iconClasses, titleClasses, cardBaseClasses } from '../styles/theme';
 
 interface ToolCardProps {
   toolId: string;
@@ -21,7 +21,7 @@ export default function ToolCard({
   const tool = dashboardTools[toolId];
   if (!tool) return null;
 
-  const { id, href, title, icon: Icon, color } = tool;
+  const { id, href, title, icon: Icon } = tool;
 
   // Sizing and style classes
 
@@ -30,18 +30,19 @@ export default function ToolCard({
       href={href}
       onMouseEnter={() => onFocus?.(id)}
       className={clsx(
-        'w-full h-full bg-white rounded-xl shadow-sm hover:shadow-md',
-        'transition-shadow duration-150 ease-out',
+        'w-full h-full',
+        cardBaseClasses,
+        'hover:shadow-md transition-shadow duration-150 ease-out',
         'flex flex-col items-center justify-center',
         sizeClasses[size],
-        isRelated && 'ring-2 ring-theme-accent'
+        isRelated && 'ring-2 ring-theme-primary'
       )}
     >
       <Icon
-        className={clsx(iconClasses[size], color, 'flex-shrink-0')}
+        className={clsx(iconClasses[size], 'text-theme-primary flex-shrink-0')}
         aria-hidden="true"
       />
-      <span className={clsx(titleClasses[size], 'text-gray-900')}>
+      <span className={clsx(titleClasses[size], 'text-theme-primary')}>
         {title}
       </span>
     </Link>

--- a/docker/web-app/src/context/ThemeContext.tsx
+++ b/docker/web-app/src/context/ThemeContext.tsx
@@ -1,71 +1,52 @@
 // /src/context/ThemeContext.tsx
-import { createContext, ReactNode, useContext, useEffect, useState } from 'react'
+import { ReactNode, useEffect } from 'react'
 import { usePathname } from 'next/navigation'
-import { dashboardTools, DashboardTool } from '@/components/dashboardTools'
 
-type Theme = {
-  background: string
-  primary: string
-  accent: string
-}
-
-const THEME_MAP: Record<string, {background:string; primary:string; accent:string}> = {
+// Map of route -> CSS variable overrides
+const THEME_MAP: Record<string, Record<string, string>> = {
   'camera-monitor': {
-    background: '#eef2ff',  // indigo-50
-    primary:    '#6366f1',  // indigo-500
-    accent:     '#c7d2fe',  // indigo-200
+    '--theme-background': '#eef2ff',
+    '--theme-primary':    '#6366f1',
+    '--theme-accent':     '#c7d2fe',
   },
   'dam-explorer': {
-    background: '#f5f3ff',  // purple-50
-    primary:    '#8b5cf6',  // purple-500
-    accent:     '#ddd6fe',  // purple-200
+    '--theme-background': '#f5f3ff',
+    '--theme-primary':    '#8b5cf6',
+    '--theme-accent':     '#ddd6fe',
   },
-  'motion': {
-    background: '#fdf2f8',  // pink-50
-    primary:    '#ec4899',  // pink-500
-    accent:     '#f9a8d4',  // pink-200
+  motion: {
+    '--theme-background': '#fdf2f8',
+    '--theme-primary':    '#ec4899',
+    '--theme-accent':     '#f9a8d4',
   },
-  'live': {
-    background: '#f0fdf4',  // green-50
-    primary:    '#22c55e',  // green-500
-    accent:     '#86efac',  // green-200
+  live: {
+    '--theme-background': '#f0fdf4',
+    '--theme-primary':    '#22c55e',
+    '--theme-accent':     '#86efac',
   },
-  'witness': {
-    background: '#fffbeb',  // yellow-50
-    primary:    '#eab308',  // yellow-500
-    accent:     '#fef08a',  // yellow-200
+  witness: {
+    '--theme-background': '#fffbeb',
+    '--theme-primary':    '#eab308',
+    '--theme-accent':     '#fef08a',
   },
-  'explorer': {
-    background: '#eff6ff',  // blue-50
-    primary:    '#3b82f6',  // blue-500
-    accent:     '#bfdbfe',  // blue-200
+  explorer: {
+    '--theme-background': '#eff6ff',
+    '--theme-primary':    '#3b82f6',
+    '--theme-accent':     '#bfdbfe',
   },
 }
-
-const ThemeContext = createContext<Theme>(THEME_MAP['camera-monitor'])
 
 export function ThemeProvider({ children }: { children: ReactNode }) {
   const pathname = usePathname()
-  const [theme, setTheme] = useState<Theme>(THEME_MAP['camera-monitor'])
 
   useEffect(() => {
-    // extract "camera-monitor" etc from /dashboard/[tool]
     const id = pathname.split('/')[2] || 'camera-monitor'
-    setTheme(THEME_MAP[id] ?? THEME_MAP['camera-monitor'])
+    const themeVars = THEME_MAP[id] ?? THEME_MAP['camera-monitor']
+    Object.entries(themeVars).forEach(([k, v]) =>
+      document.documentElement.style.setProperty(k, v)
+    )
   }, [pathname])
 
-  useEffect(() => {
-    // apply CSS vars
-    for (const [k, v] of Object.entries(theme)) {
-      document.documentElement.style.setProperty(`--theme-${k}`, v)
-    }
-  }, [theme])
-
-  return (
-    <ThemeContext.Provider value={theme}>
-      {children}
-    </ThemeContext.Provider>
-  )
+  return <>{children}</>
 }
 
-export const useTheme = () => useContext(ThemeContext)

--- a/docker/web-app/src/styles/globals.css
+++ b/docker/web-app/src/styles/globals.css
@@ -15,18 +15,13 @@ html, body, h1, h2, h3, h4, h5, h6, p, ul, ol, figure, blockquote {
 }
 
 /* ---- Base Styles ---- */
-:root {
-  --bg-color: #f8f9fb;
-  --text-color: #1e1e1e;
-}
-
 body {
   min-height: 100vh;
   line-height: 1.6;
   font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
                Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
-  background-color: var(--bg-color);
-  color: var(--text-color);
+  background-color: var(--color-background);
+  color: var(--color-text);
 }
 
 img, picture, video {
@@ -36,7 +31,22 @@ img, picture, video {
 
 a {
   text-decoration: none;
-  color: inherit;
+  color: var(--color-primary);
+}
+
+/* Input baseline */
+.input {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  padding: 0.5rem 0.75rem;
+  border-radius: var(--radius-md);
+  font-size: 0.875rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+.input:focus {
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px var(--color-primary-bg);
+  outline: none;
 }
 
 /* Theme utilities */
@@ -48,6 +58,13 @@ a {
   .text-theme-accent   { color:            var(--theme-accent)     !important; }
   .ring-theme-primary  { --tw-ring-color:  var(--theme-primary)    !important; }
   .ring-theme-accent   { --tw-ring-color:  var(--theme-accent)     !important; }
+
+  .bg-surface         { background-color: var(--color-surface) !important; }
+  .text-color-muted   { color:            var(--color-muted)  !important; }
+  .border-color-border{ border-color:     var(--color-border) !important; }
+  .bg-color-primary-bg{ background-color: var(--color-primary-bg) !important; }
+  .bg-color-accent-bg { background-color: var(--color-accent-bg)  !important; }
+  .border-theme-primary{ border-color:    var(--theme-primary)   !important; }
 }
 
 .is-selected { @apply ring-2 ring-theme-accent bg-theme-accent/10; }

--- a/docker/web-app/src/styles/theme.ts
+++ b/docker/web-app/src/styles/theme.ts
@@ -5,6 +5,8 @@ export const gridStyle: CSSProperties = {
   gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
 };
 
+export const cardBaseClasses = 'bg-surface rounded-lg shadow-sm border border-color-border';
+
 export const sizeClasses: Record<'small' | 'medium' | 'large', string> = {
   small:  'p-2 sm:p-4 min-h-[100px] sm:min-h-[120px]',
   medium: 'p-3 sm:p-6 min-h-[120px] sm:min-h-[160px]',

--- a/docker/web-app/src/styles/tokens.css
+++ b/docker/web-app/src/styles/tokens.css
@@ -16,4 +16,25 @@
   --container-md : 768px;
   --container-lg : 1024px;
   --container-xl : 1280px;
+
+  /* Colors */
+  --color-background: #f7f9fc;
+  --color-surface:    #ffffff;
+  --color-border:     #e5e7eb; /* gray-200 */
+  --color-text:       #1f2937; /* gray-800 */
+  --color-muted:      #6b7280; /* gray-500 */
+  --color-primary:    #3b82f6; /* blue-500 */
+  --color-primary-bg: #eff6ff; /* blue-50 */
+  --color-accent:     #a855f7; /* purple-500 */
+  --color-accent-bg:  #f5f3ff; /* purple-50 */
+
+  /* Radii */
+  --radius-sm: 4px;
+  --radius-md: 6px;
+  --radius-lg: 8px;
+
+  /* Shadows */
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.05);
+  --shadow-md: 0 4px 6px rgba(0,0,0,0.1);
+  --shadow-lg: 0 10px 15px rgba(0,0,0,0.15);
 }


### PR DESCRIPTION
## Summary
- add color, radius, and shadow tokens and global input utility
- refactor ThemeProvider to set CSS vars per tool route
- align cards, sidebar, search, and DAM explorer with new tokens

## Testing
- `cd docker/web-app && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897b885fa2883268b67f7d8db8b59da