### PR TITLE
feat: add 2.5D layered explorer

### DIFF
--- a/docker/web-app/package.json
+++ b/docker/web-app/package.json
@@ -17,34 +17,38 @@
     "test": "rm -rf .tmp-test && tsc -p tsconfig.test.json && node --test .tmp-test"
   },
   "dependencies": {
+    "@headlessui/react": "^1.7.18",
+    "@react-three/drei": "^9.56.7",
+    "@react-three/fiber": "^8.13.5",
+    "@tanstack/react-query": "^5.83.0",
+    "@tanstack/react-query-devtools": "^5.83.0",
+    "amqplib": "^0.10.3",
+    "axios": "^1.6.0",
+    "clsx": "^2.0.0",
+    "gl-react": "^5.2.0",
+    "gl-react-dom": "^5.2.1",
+    "lucide-react": "^0.357.0",
+    "mitt": "^3.0.1",
     "next": "14.0.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "amqplib": "^0.10.3",
     "react-icons": "^4.10.1",
-    "@tanstack/react-query-devtools": "^5.83.0",
-    "@tanstack/react-query": "^5.83.0",
-    "axios": "^1.6.0",
-    "lucide-react": "^0.357.0",
-    "clsx": "^2.0.0",
-    "tailwindcss": "^3.3.6",
-    "@headlessui/react": "^1.7.18",
-    "mitt": "^3.0.1",
-    "gl-react": "^5.2.0",
-    "gl-react-dom": "^5.2.1",
+    "sqlite": "^5.1.1",
     "sqlite3": "^5.1.7",
-    "sqlite": "^5.1.1"
+    "tailwindcss": "^3.3.6",
+    "three": "^0.179.1"
   },
   "devDependencies": {
     "@types/node": "^20.9.0",
     "@types/react": "^18.2.37",
     "@types/react-dom": "^18.2.15",
-    "typescript": "^5.2.2",
+    "@types/three": "^0.179.0",
+    "autoprefixer": "^10.4.16",
     "eslint": "^8.54.0",
     "eslint-config-next": "14.0.4",
-    "autoprefixer": "^10.4.16",
     "postcss": "^8.4.31",
-    "prettier": "^3.2.5"
+    "prettier": "^3.2.5",
+    "typescript": "^5.2.2"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/docker/web-app/src/app/dashboard/README.md
+++ b/docker/web-app/src/app/dashboard/README.md
@@ -12,3 +12,6 @@ Tools are rendered in primary/secondary/tertiary sections based on activity and 
 | /dashboard/motion               | Motion Tool        |
 | /dashboard/live                 | Live Monitor       |
 | /dashboard/witness              | Witness Tool       |
+| /dashboard/explorer/layered     | Layered Explorer   |
+
+The layered explorer is experimental and does not replace the existing file explorer.

--- a/docker/web-app/src/app/dashboard/explorer/layered/page.tsx
+++ b/docker/web-app/src/app/dashboard/explorer/layered/page.tsx
@@ -1,0 +1,18 @@
+'use client';
+import dynamic from 'next/dynamic';
+
+// SSR disabled because WebGL needs the browser
+const LayeredExplorer = dynamic(() => import('@/components/LayeredFS/LayeredExplorer'), {
+  ssr: false,
+  loading: () => (
+    <div className="w-full h-[80vh] flex items-center justify-center text-gray-500">Booting GL…</div>
+  ),
+});
+
+export default function Page() {
+  return (
+    <div className="w-screen h-[calc(100vh-2rem)] bg-[#0f1116]">
+      <LayeredExplorer />
+    </div>
+  );
+}

--- a/docker/web-app/src/components/LayeredFS/LayeredExplorer.tsx
+++ b/docker/web-app/src/components/LayeredFS/LayeredExplorer.tsx
@@ -1,0 +1,239 @@
+/**
+Experimental 2.5D file explorer using @react-three/fiber.
+Folders are placed on depth layers and files render as thumbnail planes.
+
+Usage:
+```tsx
+<LayeredExplorer /> // requires AssetProvider context
+```
+*/
+
+'use client';
+
+import React, { useMemo, useRef, useCallback } from 'react';
+import * as THREE from 'three';
+import { Canvas, useFrame } from '@react-three/fiber';
+import { Html, Line as DreiLine } from '@react-three/drei';
+import { useAssets } from '../../providers/AssetProvider';
+import { bus } from '../../lib/eventBus';
+import { layeredLayout } from './layout';
+import type { TreeSnapshot, TreeNode, FolderNode } from './types';
+
+// Build a TreeSnapshot from provider data
+function buildSnapshot(
+  folders: Array<{ name: string; path: string; children: any[] }>,
+  assets: Array<{ id: string; name: string; path: string; thumbnail?: string; mime?: string; size?: number; kind?: string }>,
+): TreeSnapshot {
+  const nodes: Record<string, TreeNode> = {};
+  const pathId = (p: string) => (p === '/' || p === '' ? 'root' : p);
+
+  const visit = (f: any, parentId: string | null, depth: number) => {
+    const id = pathId(f.path);
+    const node: FolderNode = {
+      id,
+      name: f.name || (f.path.split('/').filter(Boolean).pop() ?? '/'),
+      path: f.path || '/',
+      depth,
+      kind: 'folder',
+      parentId: parentId ?? null,
+      childIds: [],
+    };
+    nodes[id] = node;
+
+    (f.children || []).forEach((c: any) => {
+      node.childIds.push(pathId(c.path));
+      visit(c, id, depth + 1);
+    });
+
+    assets.filter(a => a.path === f.path).forEach(a => {
+      const fid = a.id;
+      nodes[fid] = {
+        id: fid,
+        name: a.name,
+        path: a.path,
+        depth: depth + 1,
+        kind: 'file',
+        parentId: id,
+        previewUrl: a.thumbnail,
+        mime: a.mime,
+        bytes: a.size,
+      };
+      node.childIds.push(fid);
+    });
+  };
+
+  if (folders.length === 0) {
+    nodes['root'] = { id: 'root', name: '/', path: '/', depth: 0, kind: 'folder', childIds: [] };
+  } else {
+    folders.forEach(root => visit(root, null, 0));
+  }
+
+  return { nodes, rootId: folders.length ? pathId(folders[0].path) : 'root' };
+}
+
+// Camera controller: dolly/drag
+function CameraRig({ focusZ }: { focusZ: React.MutableRefObject<number> }) {
+  const cam = useRef<THREE.PerspectiveCamera>(null);
+  const state = useRef({ x: 0, y: 0, z: 12 });
+  const drag = useRef<{ x?: number; y?: number }>({});
+
+  const onWheel = useCallback((e: WheelEvent) => {
+    state.current.z = Math.max(3, Math.min(80, state.current.z + Math.sign(e.deltaY)));
+  }, []);
+  const onDown = useCallback((e: PointerEvent) => {
+    drag.current = { x: e.clientX, y: e.clientY };
+  }, []);
+  const onMove = useCallback((e: PointerEvent) => {
+    if (drag.current.x == null || drag.current.y == null) return;
+    const dx = (e.clientX - drag.current.x) * 0.01;
+    const dy = (e.clientY - drag.current.y) * 0.01;
+    state.current.x -= dx * (state.current.z / 10);
+    state.current.y += dy * (state.current.z / 10);
+    drag.current = { x: e.clientX, y: e.clientY };
+  }, []);
+  const onUp = useCallback(() => {
+    drag.current = {};
+  }, []);
+
+  useFrame(() => {
+    if (!cam.current) return;
+    const targetZ = Math.max(4, focusZ.current + 7);
+    state.current.z += (targetZ - state.current.z) * 0.06;
+    cam.current.position.set(state.current.x, state.current.y, state.current.z);
+    cam.current.lookAt(state.current.x, state.current.y, 0);
+    cam.current.rotation.x = THREE.MathUtils.degToRad(-12);
+  });
+
+  React.useEffect(() => {
+    const dom = (cam.current?.parent as any)?.__r3f.root?.gl.domElement as HTMLElement;
+    if (!dom) return;
+    dom.addEventListener('wheel', onWheel, { passive: true });
+    dom.addEventListener('pointerdown', onDown);
+    window.addEventListener('pointermove', onMove);
+    window.addEventListener('pointerup', onUp);
+    return () => {
+      dom.removeEventListener('wheel', onWheel);
+      dom.removeEventListener('pointerdown', onDown);
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', onUp);
+    };
+  }, [onWheel, onDown, onMove, onUp]);
+
+  return <perspectiveCamera ref={cam} fov={50} near={0.1} far={1000} position={[0, 0, 12]} />;
+}
+
+function Edge({ a, b }: { a: { x: number; y: number; z: number }; b: { x: number; y: number; z: number } }) {
+  const mid = { x: (a.x + b.x) / 2, y: (a.y + b.y) / 2 + 0.3, z: a.z + 0.001 };
+  return (
+    // @ts-ignore drei line types
+    <DreiLine
+      points={[
+        new THREE.Vector3(a.x, a.y, a.z + 0.001),
+        new THREE.Vector3(mid.x, mid.y, mid.z),
+        new THREE.Vector3(b.x, b.y, b.z + 0.001),
+      ]}
+      lineWidth={2}
+      color="#6aa2ff"
+    />
+  );
+}
+
+function FileCard({ node, pos }: { node: TreeNode; pos: { x: number; y: number; z: number } }) {
+  const [tex, setTex] = React.useState<THREE.Texture | null>(null);
+  React.useEffect(() => {
+    if (node.kind === 'file' && (node as any).previewUrl) {
+      new THREE.TextureLoader().load((node as any).previewUrl!, (t: THREE.Texture) => {
+        t.needsUpdate = true;
+        setTex(t);
+      });
+    }
+  }, [node]);
+
+  const click = () => {
+    if (node.kind === 'file') bus.emit('preview', { id: node.id });
+  };
+
+  return (
+    <group position={[pos.x, pos.y, pos.z]} onClick={click}>
+      <mesh>
+        <planeGeometry args={[1.6, 1.0]} />
+        <meshBasicMaterial map={tex ?? undefined} color={tex ? undefined : '#1f2937'} />
+      </mesh>
+      <Html distanceFactor={15} position={[0, -0.72, 0.01]} transform occlude>
+        <div style={{ fontSize: 12, padding: '2px 6px', borderRadius: 6, background: 'rgba(0,0,0,0.45)', color: '#fff', whiteSpace: 'nowrap' }}>
+          {node.name}
+        </div>
+      </Html>
+    </group>
+  );
+}
+
+function FolderBar({ node, pos, onFocus }: { node: TreeNode; pos: { x: number; y: number; z: number }; onFocus: () => void }) {
+  return (
+    <group position={[pos.x, pos.y, pos.z]}>
+      <mesh onClick={onFocus}>
+        <shapeGeometry args={[roundedRectShape(2.2, 0.5, 0.08)]} />
+        <meshBasicMaterial color="#2b2f3a" />
+      </mesh>
+      <Html distanceFactor={20} position={[0, 0, 0.01]} transform>
+        <div style={{ color: '#dfe6f3', fontWeight: 600 }}>{node.name}</div>
+      </Html>
+    </group>
+  );
+}
+
+function roundedRectShape(w: number, h: number, r: number) {
+  const s = new THREE.Shape();
+  const x = -w / 2,
+    y = -h / 2;
+  s.moveTo(x + r, y);
+  s.lineTo(x + w - r, y);
+  s.quadraticCurveTo(x + w, y, x + w, y + r);
+  s.lineTo(x + w, y + h - r);
+  s.quadraticCurveTo(x + w, y + h, x + w - r, y + h);
+  s.lineTo(x + r, y + h);
+  s.quadraticCurveTo(x, y + h, x, y + h - r);
+  s.lineTo(x, y + r);
+  s.quadraticCurveTo(x, y, x + r, y);
+  return s;
+}
+
+export default function LayeredExplorer() {
+  const { view: assets, folders, foldersLoading } = useAssets();
+  const snapshot = useMemo(() => buildSnapshot(folders, assets), [folders, assets]);
+  const layout = useMemo(() => layeredLayout(snapshot), [snapshot]);
+  const focusZ = useRef(0);
+  const focusFolder = useCallback((z: number) => {
+    focusZ.current = z;
+  }, []);
+
+  if (foldersLoading) {
+    return <div className="w-full h-full flex items-center justify-center text-gray-500">Loading…</div>;
+  }
+
+  return (
+    <div className="h-full w-full">
+      <Canvas dpr={[1, 2]} gl={{ antialias: true }}>
+        <ambientLight intensity={0.8} />
+        <CameraRig focusZ={focusZ} />
+
+        {layout.edges.map((e, i) => {
+          const a = layout.items[e.from];
+          const b = layout.items[e.to];
+          if (!a || !b) return null;
+          return <Edge key={i} a={a} b={b} />;
+        })}
+
+        {Object.values(snapshot.nodes).map(n => {
+          const p = layout.items[n.id];
+          if (!p) return null;
+          return n.kind === 'folder' ? (
+            <FolderBar key={n.id} node={n} pos={p} onFocus={() => focusFolder(p.z)} />
+          ) : (
+            <FileCard key={n.id} node={n} pos={p} />
+          );
+        })}
+      </Canvas>
+    </div>
+  );
+}

--- a/docker/web-app/src/components/LayeredFS/layout.ts
+++ b/docker/web-app/src/components/LayeredFS/layout.ts
@@ -1,0 +1,77 @@
+/**
+Utilities to position folder and file nodes into 2.5D layers.
+Each folder depth maps to a Z offset while children are placed in a grid.
+*/
+
+import { TreeSnapshot, FolderNode, TreeNode } from './types';
+
+export interface Positioned {
+  id: string;
+  x: number;
+  y: number;
+  z: number; // negative numbers move away from camera
+  w: number;
+  h: number;
+}
+
+export interface LayoutResult {
+  items: Record<string, Positioned>;
+  edges: Array<{ from: string; to: string }>;
+}
+
+const LAYER_GAP = 3;
+const CELL_W = 1.6;
+const CELL_H = 1.0;
+const PAD_X = 0.4;
+const PAD_Y = 0.4;
+const COLS = 6;
+
+/**
+ * Compute positions for every node and connecting edges.
+ *
+ * Example:
+ * ```ts
+ * const layout = layeredLayout(snapshot);
+ * console.log(layout.items[nodeId]); // {x,y,z,w,h}
+ * ```
+ */
+export function layeredLayout(tree: TreeSnapshot): LayoutResult {
+  const items: Record<string, Positioned> = {};
+  const edges: Array<{ from: string; to: string }> = [];
+
+  const childrenByParent: Record<string, TreeNode[]> = {};
+  Object.values(tree.nodes).forEach(n => {
+    if (n.parentId) (childrenByParent[n.parentId] ||= []).push(n);
+  });
+
+  for (const node of Object.values(tree.nodes)) {
+    if (node.kind !== 'folder') continue;
+    const folder = node as FolderNode;
+    const z = -node.depth * LAYER_GAP;
+    items[node.id] = { id: node.id, x: 0, y: 0, z, w: 2.2, h: 0.5 };
+
+    const kids = (childrenByParent[node.id] || []).sort((a, b) => {
+      if (a.kind !== b.kind) return a.kind === 'folder' ? -1 : 1;
+      return a.name.localeCompare(b.name);
+    });
+
+    kids.forEach((child, i) => {
+      const col = i % COLS;
+      const row = Math.floor(i / COLS);
+      const x = (col - (COLS - 1) / 2) * (CELL_W + PAD_X);
+      const y = -(row + 1) * (CELL_H + PAD_Y) - 0.8;
+      const childPos: Positioned = {
+        id: child.id,
+        x,
+        y,
+        z,
+        w: CELL_W,
+        h: CELL_H,
+      };
+      items[child.id] = childPos;
+      edges.push({ from: node.id, to: child.id });
+    });
+  }
+
+  return { items, edges };
+}

--- a/docker/web-app/src/components/LayeredFS/types.ts
+++ b/docker/web-app/src/components/LayeredFS/types.ts
@@ -1,0 +1,35 @@
+/**
+Interfaces describing nodes for the Layered Explorer.
+Used by layeredLayout and LayeredExplorer to build a 2.5D view.
+*/
+
+export type NodeKind = 'folder' | 'file';
+
+export interface BaseNode {
+  id: string;
+  name: string;
+  path: string; // full path, e.g. "/Photos/Trip"
+  depth: number; // root = 0
+  kind: NodeKind;
+  parentId?: string | null;
+}
+
+export interface FileNode extends BaseNode {
+  kind: 'file';
+  mime?: string;
+  bytes?: number;
+  previewUrl?: string; // thumbnail or poster URL
+}
+
+export interface FolderNode extends BaseNode {
+  kind: 'folder';
+  childIds: string[];
+  expanded?: boolean;
+}
+
+export type TreeNode = FileNode | FolderNode;
+
+export interface TreeSnapshot {
+  nodes: Record<string, TreeNode>;
+  rootId: string;
+}

--- a/docker/web-app/src/components/README.md
+++ b/docker/web-app/src/components/README.md
@@ -20,3 +20,20 @@ Attach `SelectableItem` to wrap children with selection and gesture handling.
   <img src={asset.thumbnail} />
 </SelectableItem>
 ```
+
+## Layered Explorer (experimental)
+
+Renders the asset tree in 2.5D using WebGL.
+
+Install deps:
+
+```
+npm install three @react-three/fiber @react-three/drei
+```
+
+Usage:
+
+```tsx
+import LayeredExplorer from '@/components/LayeredFS/LayeredExplorer';
+<LayeredExplorer />
+```

--- a/docker/web-app/src/components/__tests__/LayeredExplorer.test.tsx
+++ b/docker/web-app/src/components/__tests__/LayeredExplorer.test.tsx
@@ -1,0 +1,28 @@
+import assert from 'node:assert';
+import test from 'node:test';
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+import LayeredExplorer from '../LayeredFS/LayeredExplorer';
+import { AssetCtx } from '../../providers/AssetProvider';
+
+test('LayeredExplorer renders canvas', () => {
+  const mockCtx = {
+    assets: [],
+    folders: [],
+    foldersLoading: false,
+    view: [],
+    filters: {},
+    setFilters: () => {},
+    vectorSearch: async () => {},
+    move: async () => {},
+    remove: async () => {},
+    refresh: () => {},
+  } as any;
+
+  const html = renderToString(
+    <AssetCtx.Provider value={mockCtx}>
+      <LayeredExplorer />
+    </AssetCtx.Provider>
+  );
+  assert.ok(html.includes('<canvas'));
+});

--- a/docker/web-app/src/components/__tests__/LayeredLayout.test.ts
+++ b/docker/web-app/src/components/__tests__/LayeredLayout.test.ts
@@ -1,0 +1,18 @@
+import assert from 'node:assert';
+import test from 'node:test';
+import { layeredLayout } from '../LayeredFS/layout';
+import type { TreeSnapshot } from '../LayeredFS/types';
+
+test('layeredLayout positions children by depth', () => {
+  const snapshot: TreeSnapshot = {
+    nodes: {
+      root: { id: 'root', name: '/', path: '/', depth: 0, kind: 'folder', childIds: ['file1'] },
+      file1: { id: 'file1', name: 'file', path: '/', depth: 1, kind: 'file', parentId: 'root' },
+    },
+    rootId: 'root',
+  };
+  const layout = layeredLayout(snapshot);
+  assert.equal(layout.items['root'].z, 0);
+  assert.equal(layout.items['file1'].z, -3);
+  assert.ok(layout.edges.find(e => e.from === 'root' && e.to === 'file1'));
+});

--- a/docker/web-app/src/components/dashboardTools.tsx
+++ b/docker/web-app/src/components/dashboardTools.tsx
@@ -97,4 +97,15 @@ export const dashboardTools: Record<string, DashboardTool> = {
     lastUsed: '2024-01-17T11:20:00Z',
     status: 'idle',
   },
+  'explorer-layered': {
+    id: 'explorer-layered',
+    href: '/dashboard/explorer/layered',
+    title: 'Layered Explorer (2.5D)',
+    icon: Eye,
+    color: dashboardColorClasses['explorer'],
+    context: 'archive',
+    relatedTools: ['dam-explorer', 'explorer'],
+    lastUsed: new Date().toISOString(),
+    status: 'active',
+  },
 };

--- a/docker/web-app/src/providers/AssetProvider.tsx
+++ b/docker/web-app/src/providers/AssetProvider.tsx
@@ -8,19 +8,11 @@ import React, {
   useState,
   useMemo,
 } from 'react';
-import { bus }            from '@/lib/eventBus';
-import { createAsset }    from '@/lib/apiAssets';
+import { bus } from '../lib/eventBus';
+import { createAsset, listAssets, listFolders, moveAssets, deleteAssets, Asset, FolderNode } from '../lib/apiAssets';
 import { useCapture }     from './CaptureContext'; // to get timecode, overlays, etc
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import {
-  listAssets,
-  listFolders,
-  moveAssets,
-  deleteAssets,
-  Asset,
-  FolderNode,
-} from '@/lib/apiAssets';
-import { videoApi } from '@/lib/videoApi'; // assumes you add a vectorSearch endpoint here
+import { videoApi } from '../lib/videoApi'; // assumes you add a vectorSearch endpoint here
 
 // ─── Types ──────────────────────────────────────────────────────────────
 interface Filters {
@@ -46,7 +38,7 @@ interface AssetCtx {
 }
 
 // ─── Context & Hook ────────────────────────────────────────────────────
-const AssetCtx = createContext<AssetCtx | null>(null);
+export const AssetCtx = createContext<AssetCtx | null>(null);
 export const useAssets = () => {
   const ctx = useContext(AssetCtx);
   if (!ctx) throw new Error('useAssets must be inside <AssetProvider>');

--- a/docker/web-app/tsconfig.test.json
+++ b/docker/web-app/tsconfig.test.json
@@ -16,6 +16,7 @@
     "src/components/ToolCard.tsx",
     "src/components/dashboardTools.tsx",
     "src/components/Cards.tsx",
+    "src/providers/AssetProvider.tsx",
     "src/hooks/useIntelligentLayout.ts"
   ]
 }


### PR DESCRIPTION
## Summary
- add LayeredFS module with types, layout helper, and WebGL LayeredExplorer component
- register Layered Explorer dashboard route and tool entry
- document experimental explorer and add basic unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897d3c6a1f08326a2fe2ec5ad963bed