### PR TITLE
fix: import intelligent layout hook separately

### DIFF
--- a/docker/web-app/src/app/page.tsx
+++ b/docker/web-app/src/app/page.tsx
@@ -2,7 +2,8 @@
 'use client';
 
 import ToolCard from '@/components/ToolCard';
-import { dashboardTools, useIntelligentLayout } from '@/components/dashboardTools';
+import { dashboardTools } from '@/components/dashboardTools';
+import { useIntelligentLayout } from '@/hooks/useIntelligentLayout';
 import { gridStyle } from '@/styles/theme';
 
 export default function HomePage() {


### PR DESCRIPTION
## Summary
- import `useIntelligentLayout` from its hook module instead of from dashboard tools

## Testing
- `npm test`
- `npm run build` *(fails: Object literal may only specify known properties, and 'duplex' does not exist in type 'RequestInit')*

## Checklist
- [x] Code is self-contained and idempotent.
- [x] No unnecessary new files or external dependencies.
- [x] Tests added or updated as appropriate.
- [ ] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_6897ed62b4808326bbe2101a258c3708