### PR TITLE
fix: make DAM Explorer search bar responsive

### DIFF
--- a/docker/web-app/src/components/DAMExplorer.tsx
+++ b/docker/web-app/src/components/DAMExplorer.tsx
@@ -412,7 +412,7 @@ const AssetExplorer: React.FC = () => {
             </div>
           </div>
 
-          <div className="flex items-center space-x-4">
+          <div className="flex items-center space-x-4 min-w-0">
             <SearchBarExtension
               placeholder="Search assets, tags, metadata..."
               onSearch={handleSearch}
@@ -420,7 +420,7 @@ const AssetExplorer: React.FC = () => {
               onResultSelect={handleResultSelect}
               availableTags={availableTags}
               availableFileTypes={availableFileTypes}
-              className="w-96"
+              className="w-full max-w-search-bar"
               showFilters
               showVectorSearch
             />

--- a/docker/web-app/src/styles/tokens.css
+++ b/docker/web-app/src/styles/tokens.css
@@ -16,6 +16,7 @@
   --container-md : 768px;
   --container-lg : 1024px;
   --container-xl : 1280px;
+  --search-bar-max-width : var(--container-md);
 
   /* Colors */
   --color-background: #f7f9fc;

--- a/docker/web-app/tailwind.config.js
+++ b/docker/web-app/tailwind.config.js
@@ -21,6 +21,7 @@ module.exports = {
         'md': 'var(--container-md)',
         'lg': 'var(--container-lg)',
         'xl': 'var(--container-xl)',
+        'search-bar': 'var(--search-bar-max-width)',
       },
       spacing: {
         'section': 'var(--section-pad-y)',


### PR DESCRIPTION
## Summary
- ensure DAM Explorer header can shrink by giving parent container `min-w-0`
- make the search bar responsive with a design-token-backed `max-w-search-bar`

## Testing
- `npm test`
- `npm run lint` *(fails: How would you like to configure ESLint?)*
- `npm run build` *(fails: Attempted import error: 'useIntelligentLayout' is not exported from '@/components/dashboardTools')*

## Checklist
- [x] Code is self-contained and idempotent.
- [x] No unnecessary new files or external dependencies.
- [ ] Tests added or updated as appropriate.
- [ ] Docs updated where needed.

------
https://chatgpt.com/codex/tasks/task_e_6897ed69335083268101299f58e06626