### PR TITLE
chore: align Go toolchain with workspace

### DIFF
--- a/.github/workflows/ci-engineer-env.yml
+++ b/.github/workflows/ci-engineer-env.yml
@@ -21,7 +21,7 @@ jobs:
 
     env:
       # Can be used for later conditional logic
-      GO_VERSION: '1.21'
+      GO_VERSION: '1.23.x'
       PYTHON_VERSION: '3.11'
 
     steps:

--- a/.github/workflows/ci-go-quality-gate.yml
+++ b/.github/workflows/ci-go-quality-gate.yml
@@ -69,7 +69,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Tools (pin staticcheck to a Go 1.22–compatible version)
+          # Tools (pin staticcheck to a Go 1.23–compatible version)
           go install honnef.co/go/tools/cmd/staticcheck@v0.5.1
           go install github.com/kisielk/errcheck@latest
           go install golang.org/x/vuln/cmd/govulncheck@latest

--- a/.github/workflows/ci-test-changed-services.yml
+++ b/.github/workflows/ci-test-changed-services.yml
@@ -73,7 +73,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
-        with: { go-version: '1.22.x' }
+        with: { go-version: '1.23.x' }
       - uses: actions/setup-python@v5
         with: { python-version: '3.11' }
       - uses: actions/setup-node@v4

--- a/.github/workflows/generate-openapi-spec.yml
+++ b/.github/workflows/generate-openapi-spec.yml
@@ -116,7 +116,7 @@ jobs:
       - name: Setup Go
         if: matrix.service.lang == 'go'
         uses: actions/setup-go@v5
-        with: { go-version: '1.22.x' }
+        with: { go-version: '1.23.x' }
 
       - name: Setup Python
         if: matrix.service.lang == 'python'

--- a/docker/capture-daemon/Dockerfile
+++ b/docker/capture-daemon/Dockerfile
@@ -1,10 +1,12 @@
 # /docker/capture-daemon/Dockerfile
 # ---------- build stage ----------
-FROM golang:1.22-alpine AS build
+ARG GO_VERSION=1.23
+FROM golang:${GO_VERSION}-alpine AS build
+ENV CGO_ENABLED=0 GOTOOLCHAIN=auto
 WORKDIR /src
 COPY go.mod ./
 COPY . .           # <-- make sure the whole daemon source is here
-RUN CGO_ENABLED=0 go build -o capture-daemon ./main.go
+RUN go build -o capture-daemon ./main.go
 
 # ---------- runtime stage ----------
 FROM alpine:3.20 AS runtime

--- a/host/services/api-gateway/Dockerfile
+++ b/host/services/api-gateway/Dockerfile
@@ -1,24 +1,35 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.22-alpine AS build
+ARG GO_VERSION=1.23
+FROM golang:${GO_VERSION}-alpine AS builder
+ENV CGO_ENABLED=0 GOTOOLCHAIN=auto
 ARG TARGETOS TARGETARCH VERSION
 WORKDIR /src
-COPY go.work ./
+
+# bring in workspace and manifests first for caching
+COPY go.work go.work.sum ./
 COPY host/services/shared/go.mod host/services/shared/go.mod
 COPY host/services/shared/go.sum host/services/shared/go.sum
 COPY host/services/api-gateway/go.mod host/services/api-gateway/go.mod
 COPY host/services/api-gateway/go.sum host/services/api-gateway/go.sum
+
+# sync workspace to resolve local modules
 RUN go work sync
+
+# now copy sources
 COPY host/services/shared/ host/services/shared/
 COPY host/services/api-gateway/ host/services/api-gateway/
+
 WORKDIR /src/host/services/api-gateway
-RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /out/api-gateway ./cmd
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    GOOS=$TARGETOS GOARCH=$TARGETARCH go build -v -o /out/api-gateway ./cmd
 
 FROM alpine:3.20
 ARG VERSION
 LABEL org.opencontainers.image.version=$VERSION
 RUN apk add --no-cache ca-certificates
-COPY --from=build /out/api-gateway /usr/local/bin/api-gateway
+COPY --from=builder /out/api-gateway /usr/local/bin/api-gateway
 EXPOSE 8080
 ENTRYPOINT ["/usr/local/bin/api-gateway"]
 

--- a/host/services/camera-proxy/Dockerfile
+++ b/host/services/camera-proxy/Dockerfile
@@ -1,24 +1,35 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.22-alpine AS build
+ARG GO_VERSION=1.23
+FROM golang:${GO_VERSION}-alpine AS builder
+ENV CGO_ENABLED=0 GOTOOLCHAIN=auto
 ARG TARGETOS TARGETARCH VERSION
 WORKDIR /src
-COPY go.work ./
+
+# bring in workspace and manifests first for caching
+COPY go.work go.work.sum ./
 COPY host/services/shared/go.mod host/services/shared/go.mod
 COPY host/services/shared/go.sum host/services/shared/go.sum
 COPY host/services/camera-proxy/go.mod host/services/camera-proxy/go.mod
 COPY host/services/camera-proxy/go.sum host/services/camera-proxy/go.sum
+
+# sync workspace to resolve local modules
 RUN go work sync
+
+# now copy sources
 COPY host/services/shared/ host/services/shared/
 COPY host/services/camera-proxy/ host/services/camera-proxy/
+
 WORKDIR /src/host/services/camera-proxy
-RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /out/camera-proxy .
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    GOOS=$TARGETOS GOARCH=$TARGETARCH go build -v -o /out/camera-proxy .
 
 FROM alpine:3.20
 ARG VERSION
 LABEL org.opencontainers.image.version=$VERSION
 RUN apk add --no-cache ca-certificates ffmpeg v4l-utils usbutils
-COPY --from=build /out/camera-proxy /usr/local/bin/camera-proxy
+COPY --from=builder /out/camera-proxy /usr/local/bin/camera-proxy
 EXPOSE 8000
 ENTRYPOINT ["/usr/local/bin/camera-proxy"]
 

--- a/host/services/capture-daemon/Dockerfile
+++ b/host/services/capture-daemon/Dockerfile
@@ -1,14 +1,16 @@
 # syntax=docker/dockerfile:1
 
 # ─── Stage 1: Build the capture-daemon binary ───────────────────────────────
-FROM golang:1.22-alpine AS builder
+ARG GO_VERSION=1.23
+FROM golang:${GO_VERSION}-alpine AS builder
+ENV CGO_ENABLED=0 GOTOOLCHAIN=auto
 ARG TARGETOS TARGETARCH VERSION
 
 RUN apk add --no-cache git ca-certificates
 WORKDIR /build
 
 # 1) Copy only go.mod (we don’t keep go.sum)
-COPY go.work ./
+COPY go.work go.work.sum ./
 COPY host/services/capture-daemon/go.mod host/services/capture-daemon/go.mod
 COPY host/services/shared/go.mod         host/services/shared/go.mod
 
@@ -22,7 +24,7 @@ RUN go mod tidy \
  && go mod vendor
 
 # 4) Compile using vendored deps
-RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -mod=vendor -o /out/capture-daemon ./main.go
+RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build -mod=vendor -o /out/capture-daemon ./main.go
 
 # ─── Stage 2: Runtime image ─────────────────────────────────────────────────
 FROM alpine:3.20

--- a/host/services/media-api/Dockerfile
+++ b/host/services/media-api/Dockerfile
@@ -1,6 +1,8 @@
 # /host/services/media-api/Dockerfile
 # Build media-api service
-FROM golang:1.22 AS build
+ARG GO_VERSION=1.23
+FROM golang:${GO_VERSION} AS build
+ENV CGO_ENABLED=0 GOTOOLCHAIN=auto
 WORKDIR /app
 COPY . .
 RUN go build -o media-api ./cmd/media-api

--- a/host/services/overlay-hub/Dockerfile
+++ b/host/services/overlay-hub/Dockerfile
@@ -1,5 +1,7 @@
 # simple Go build
-FROM golang:1.22-alpine AS build
+ARG GO_VERSION=1.23
+FROM golang:${GO_VERSION}-alpine AS build
+ENV CGO_ENABLED=0 GOTOOLCHAIN=auto
 
 WORKDIR /src
 COPY . .


### PR DESCRIPTION
## Summary
- upgrade Go service Dockerfiles to 1.23 with automatic toolchain fetching
- bump CI workflows to Go 1.23.x for consistent builds

## Testing
- `go test ./host/services/camera-proxy/... ./host/services/api-gateway/... -count=1`
- `go test ./host/services/capture-daemon/... -count=1`
- `go test ./host/services/media-api/... ./host/services/overlay-hub/... -count=1`

## Checklist
- [x] Code is self-contained and idempotent.
- [x] No unnecessary new files or external dependencies.
- [x] Tests added or updated as appropriate.
- [x] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_689832cc0208832697c1379a3b8d4ec2