### PR TITLE
refactor: update nginx proxy defaults

### DIFF
--- a/docker/nginx/proxy_defaults.conf
+++ b/docker/nginx/proxy_defaults.conf
@@ -1,6 +1,11 @@
-# proxy_defaults.conf
 proxy_http_version 1.1;
-proxy_set_header Upgrade $http_upgrade;
-proxy_set_header Connection $http_connection;
-proxy_set_header Host $host;
+
+# Canonical forward headers
+proxy_set_header Host              $host;
+proxy_set_header X-Real-IP         $remote_addr;
+proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+proxy_set_header X-Forwarded-Proto $scheme;
+
+# Reasonable defaults
+proxy_buffering off;
 proxy_cache_bypass $http_upgrade;


### PR DESCRIPTION
## Summary
- refresh default proxy headers for nginx

## Testing
- `PYTHONPATH=. pytest tests/ -q` *(fails: EventBus.publish() takes 2 positional arguments but 3 were given)*

## Checklist
- [ ] Code is self-contained and idempotent.
- [ ] No unnecessary new files or external dependencies.
- [ ] Tests added or updated as appropriate.
- [ ] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_6898f8ba86d083269b3ede34ab2454ae