### PR TITLE
Ensure nginx snippets written only when missing

### DIFF
--- a/docker/nginx/entrypoint.sh
+++ b/docker/nginx/entrypoint.sh
@@ -7,9 +7,7 @@ set -e
 #   /entrypoint.sh
 
 # write snippet files directly into /etc/nginx
-cat >/etc/nginx/proxy_defaults.conf <<'EOF'
-# only create snippets if they don't already exist
-[ -f /etc/nginx/proxy_defaults.conf ] || cat >/etc/nginx/proxy_defaults.conf <<'EOF'
+[ -f /etc/nginx/proxy_defaults.conf ] || cat > /etc/nginx/proxy_defaults.conf <<'EOF'
 proxy_http_version 1.1;
 proxy_set_header Upgrade $http_upgrade;
 proxy_set_header Connection $http_connection;
@@ -17,14 +15,14 @@ proxy_set_header Host $host;
 proxy_cache_bypass $http_upgrade;
 EOF
 
-[ -f /etc/nginx/proxy_ws.conf ] || cat >/etc/nginx/proxy_ws.conf <<'EOF'
+[ -f /etc/nginx/proxy_ws.conf ] || cat > /etc/nginx/proxy_ws.conf <<'EOF'
 proxy_http_version 1.1;
 proxy_set_header Upgrade $http_upgrade;
 proxy_set_header Connection "Upgrade";
 proxy_set_header Host $host;
 EOF
 
-[ -f /etc/nginx/proxy_nobuf.conf ] || cat >/etc/nginx/proxy_nobuf.conf <<'EOF'
+[ -f /etc/nginx/proxy_nobuf.conf ] || cat > /etc/nginx/proxy_nobuf.conf <<'EOF'
 proxy_pass_request_headers on;
 proxy_buffering off;
 proxy_cache off;

--- a/tests/test_nginx_entrypoint_snippets.py
+++ b/tests/test_nginx_entrypoint_snippets.py
@@ -1,0 +1,68 @@
+"""Tests for nginx snippet creation.
+
+Run with:
+    pytest tests/test_nginx_entrypoint_snippets.py
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import textwrap
+
+
+SNIPPETS = {
+    "proxy_defaults.conf": textwrap.dedent(
+        """\
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $http_connection;
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+        """
+    ),
+    "proxy_ws.conf": textwrap.dedent(
+        """\
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
+        proxy_set_header Host $host;
+        """
+    ),
+    "proxy_nobuf.conf": textwrap.dedent(
+        """\
+        proxy_pass_request_headers on;
+        proxy_buffering off;
+        proxy_cache off;
+        """
+    ),
+}
+
+
+def _run_block(target: Path, name: str, snippet: str) -> None:
+    """Execute the conditional write block for a given snippet file."""
+
+    block = (
+        f"[ -f {target}/{name} ] || cat > {target}/{name} <<'EOF'\n"
+        f"{snippet}EOF\n"
+    )
+    subprocess.run(["bash", "-c", block], check=True)
+
+
+def test_snippet_creation_is_idempotent(tmp_path: Path) -> None:
+    """Snippet blocks create files once and do not overwrite custom edits."""
+
+    nginx_dir = tmp_path / "etc" / "nginx"
+    nginx_dir.mkdir(parents=True)
+
+    for name, content in SNIPPETS.items():
+        path = nginx_dir / name
+
+        _run_block(nginx_dir, name, content)
+        assert path.read_text() == content
+
+        path.write_text("custom\n")
+        _run_block(nginx_dir, name, content)
+        assert path.read_text() == "custom\n"
+


### PR DESCRIPTION
## Summary
- avoid overwriting existing nginx snippets by writing them only when absent
- test snippet creation is idempotent for proxy_defaults, ws, and nobuf configs

## Testing
- `PYTHONPATH=$PWD pytest --noconftest tests/test_nginx_entrypoint_snippets.py -q`

## Checklist
- [x] Code is self-contained and idempotent.
- [x] No unnecessary new files or external dependencies.
- [x] Tests added or updated as appropriate.
- [ ] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_6898f8c1722883268bba9f47be8b820b