### PR TITLE
Expose capture-daemon port 9000

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -117,6 +117,8 @@ services:
     init: false
     privileged: true                        # Needed for /dev and v4l2
     pid: host
+    ports:
+      - "9000:9000"
     environment:
       EVENT_BROKER_URL: "amqp://video:video@rabbitmq:5672/"
       NEXT_PUBLIC_LOGIN_URL: "https://idp.example.com/login"


### PR DESCRIPTION
## Summary
- expose capture-daemon service on host port 9000

## Testing
- `python -m pytest tests/test_api_client.py -q` *(fails: subprocess.CalledProcessError: Command '['stat', '-f', '-c', '%T', '/data/db']' returned non-zero exit status 1)*
- `docker compose up -d capture-daemon` *(fails: command not found: docker)*

## Checklist
- [x] Code is self-contained and idempotent.
- [x] No unnecessary new files or external dependencies.
- [ ] Tests added or updated as appropriate.
- [ ] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_68991c717fd483269d6c8924368a3db7