### PR TITLE
docs(camera-proxy): clarify capture sources

### DIFF
--- a/host/services/camera-proxy/README.md
+++ b/host/services/camera-proxy/README.md
@@ -2,6 +2,13 @@
 
 Transparent proxy exposing host cameras to containerized services.
 
+## Capture sources
+
+[capture-daemon](../capture-daemon/README.md) can ingest streams from both
+local devices and network broadcasts, while camera-proxy only exposes hardware
+attached to the host. For remote network feeds, refer to the capture-daemon's
+[network broadcast section](../capture-daemon/README.md#network-broadcast).
+
 ## Build
 ```bash
 docker build -t camera-proxy -f host/services/camera-proxy/Dockerfile .


### PR DESCRIPTION
## Summary
- clarify that capture-daemon handles local and network sources, while camera-proxy only exposes local hardware
- link to capture-daemon's network broadcast section

## Testing
- `go test ./...` (camera-proxy)
- `go test ./...` (capture-daemon)

## Checklist
- [x] Code is self-contained and idempotent.
- [x] No unnecessary new files or external dependencies.
- [x] Tests added or updated as appropriate.
- [x] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_6899239554e88326a0af0c05f21b983f