### PR TITLE
Add supervisor control-plane service and client

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -229,6 +229,26 @@ services:
     restart: unless-stopped
 
 
+  supervisor:
+    build:
+      context: host/services/supervisor
+      dockerfile: Dockerfile
+    image: cdaprod/supervisor:latest
+    container_name: thatdamtoolbox-supervisor
+    networks: [damnet]
+    ports: ["8070:8070"]
+    environment:
+      SUPERVISOR_API_KEY: "changeme"
+      EVENT_BROKER_URL: "amqp://video:video@rabbitmq:5672/"
+      EVENT_PREFIX: "overlay"
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8070/health"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+    depends_on:
+      - rabbitmq
+    restart: unless-stopped
   ########################################################################
   # 3d. Golang - host api gateway
   ########################################################################

--- a/go.work
+++ b/go.work
@@ -7,6 +7,7 @@ use (
 	./host/services/discovery
 	./host/services/media-api
 	./host/services/overlay-hub
-	./host/services/shared
+        ./host/services/supervisor
+        ./host/services/shared
 	./host/services/shared/hostcap/v4l2probe
 )

--- a/host/services/shared/supervisor/client.go
+++ b/host/services/shared/supervisor/client.go
@@ -1,0 +1,88 @@
+package supervisor
+
+// Package supervisor provides a minimal client for the supervisor control plane.
+//
+// Example:
+//   os.Setenv("SUPERVISOR_URL", "http://supervisor:8070")
+//   os.Setenv("SUPERVISOR_API_KEY", "secret")
+//   supervisor.Register(ctx, supervisor.Agent{ID: "cam1"})
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"os"
+	"time"
+)
+
+// Agent metadata sent to the supervisor.
+type Agent struct {
+	ID       string         `json:"id"`
+	Class    string         `json:"class,omitempty"`
+	Version  string         `json:"version,omitempty"`
+	Features []string       `json:"features,omitempty"`
+	Address  string         `json:"address,omitempty"`
+	Meta     map[string]any `json:"meta,omitempty"`
+}
+
+func client() (baseURL, apiKey, token string) {
+	return os.Getenv("SUPERVISOR_URL"), os.Getenv("SUPERVISOR_API_KEY"), os.Getenv("SUPERVISOR_TOKEN")
+}
+
+// Register registers agent a with the supervisor.
+// If SUPERVISOR_URL is unset, Register is a no-op.
+func Register(ctx context.Context, a Agent) error {
+	baseURL, apiKey, token := client()
+	if baseURL == "" {
+		return nil
+	}
+	b, err := json.Marshal(a)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+"/register", bytes.NewReader(b))
+	if err != nil {
+		return err
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	} else if apiKey != "" {
+		req.Header.Set("X-API-Key", apiKey)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	hc := &http.Client{Timeout: 5 * time.Second}
+	resp, err := hc.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	return nil
+}
+
+// Heartbeat sends a heartbeat for id to the supervisor.
+// If SUPERVISOR_URL is unset, Heartbeat is a no-op.
+func Heartbeat(ctx context.Context, id string) error {
+	baseURL, apiKey, token := client()
+	if baseURL == "" {
+		return nil
+	}
+	b, _ := json.Marshal(map[string]string{"id": id})
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+"/heartbeat", bytes.NewReader(b))
+	if err != nil {
+		return err
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	} else if apiKey != "" {
+		req.Header.Set("X-API-Key", apiKey)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	hc := &http.Client{Timeout: 5 * time.Second}
+	resp, err := hc.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	return nil
+}

--- a/host/services/shared/supervisor/client_test.go
+++ b/host/services/shared/supervisor/client_test.go
@@ -1,0 +1,17 @@
+package supervisor
+
+import (
+	"context"
+	"os"
+	"testing"
+)
+
+func TestNoop(t *testing.T) {
+	os.Unsetenv("SUPERVISOR_URL")
+	if err := Register(context.Background(), Agent{ID: "x"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := Heartbeat(context.Background(), "x"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/host/services/supervisor/Dockerfile
+++ b/host/services/supervisor/Dockerfile
@@ -1,0 +1,41 @@
+# syntax=docker/dockerfile:1.5
+
+ARG GO_VERSION=1.23
+FROM golang:${GO_VERSION}-alpine AS builder
+ARG TARGETOS TARGETARCH VERSION
+ENV CGO_ENABLED=0 GOTOOLCHAIN=auto
+WORKDIR /src
+
+# manifests
+COPY host/services/shared/go.mod          host/services/shared/go.mod
+COPY host/services/shared/go.sum          host/services/shared/go.sum
+COPY host/services/supervisor/go.mod      host/services/supervisor/go.mod
+COPY host/services/supervisor/go.sum      host/services/supervisor/go.sum
+
+# workspace
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    sh -ceu '\
+      go work init ./host/services/supervisor; \
+      go work use  ./host/services/shared; \
+      go work sync \
+    '
+
+# sources
+COPY host/services/shared/            host/services/shared/
+COPY host/services/supervisor/        host/services/supervisor/
+
+# build
+WORKDIR /src/host/services/supervisor
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    GOOS=$TARGETOS GOARCH=$TARGETARCH go build -v -o /out/supervisor ./cmd
+
+# runtime
+FROM alpine:3.20
+ARG VERSION
+LABEL org.opencontainers.image.version=$VERSION
+RUN apk add --no-cache ca-certificates
+COPY --from=builder /out/supervisor /usr/local/bin/supervisor
+EXPOSE 8070
+ENTRYPOINT ["/usr/local/bin/supervisor"]

--- a/host/services/supervisor/README.md
+++ b/host/services/supervisor/README.md
@@ -1,0 +1,15 @@
+# supervisor
+
+Optional control-plane for agent registry and heartbeats.
+
+## Usage
+
+```
+go run ./cmd/supervisor/main.go -addr :8070
+```
+
+Endpoints:
+- `GET /health`
+- `GET /agents`
+- `POST /register`
+- `POST /heartbeat`

--- a/host/services/supervisor/cmd/supervisor/main.go
+++ b/host/services/supervisor/cmd/supervisor/main.go
@@ -1,0 +1,217 @@
+package main
+
+// supervisor provides an optional control-plane for agents.
+//
+// Example:
+//   go run ./cmd/supervisor/main.go -addr :8070
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Cdaprod/ThatDamToolbox/host/services/shared/bus"
+	"github.com/MicahParks/keyfunc"
+	"github.com/golang-jwt/jwt/v4"
+)
+
+// Agent describes a registered agent.
+type Agent struct {
+	ID            string         `json:"id"`
+	Class         string         `json:"class,omitempty"`
+	Version       string         `json:"version,omitempty"`
+	Features      []string       `json:"features,omitempty"`
+	Status        string         `json:"status"`
+	LastHeartbeat time.Time      `json:"last_heartbeat"`
+	Address       string         `json:"address,omitempty"`
+	Meta          map[string]any `json:"meta,omitempty"`
+}
+
+// Registry holds agents in memory.
+type Registry struct {
+	mu     sync.RWMutex
+	agents map[string]*Agent
+}
+
+func NewRegistry() *Registry { return &Registry{agents: make(map[string]*Agent)} }
+
+// Upsert adds or updates an agent entry.
+func (r *Registry) Upsert(a Agent) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.agents[a.ID] = &a
+}
+
+// Heartbeat refreshes an agent's status and heartbeat timestamp.
+func (r *Registry) Heartbeat(id string, meta map[string]any) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	a, ok := r.agents[id]
+	if !ok {
+		a = &Agent{ID: id}
+		r.agents[id] = a
+	}
+	a.Status = "healthy"
+	a.LastHeartbeat = time.Now()
+	if meta != nil {
+		if a.Meta == nil {
+			a.Meta = make(map[string]any)
+		}
+		for k, v := range meta {
+			a.Meta[k] = v
+		}
+	}
+}
+
+// Snapshot returns a copy of the registry.
+func (r *Registry) Snapshot() []Agent {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]Agent, 0, len(r.agents))
+	for _, a := range r.agents {
+		out = append(out, *a)
+	}
+	return out
+}
+
+// MarkStale marks agents stale if their heartbeat exceeds ttl.
+func (r *Registry) MarkStale(ttl time.Duration) {
+	cutoff := time.Now().Add(-ttl)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, a := range r.agents {
+		if a.Status == "healthy" && a.LastHeartbeat.Before(cutoff) {
+			a.Status = "stale"
+		}
+	}
+}
+
+var (
+	reg         *Registry
+	apiKey      string
+	jwks        *keyfunc.JWKS
+	eventPrefix string
+)
+
+func main() {
+	addr := flag.String("addr", ":8070", "HTTP bind address")
+	jwksURL := flag.String("jwks-url", os.Getenv("JWKS_URL"), "JWKS endpoint URL")
+	ttl := flag.Duration("stale-ttl", 30*time.Second, "stale TTL")
+	flag.Parse()
+
+	apiKey = os.Getenv("SUPERVISOR_API_KEY")
+	eventPrefix = os.Getenv("EVENT_PREFIX")
+	if eventPrefix == "" {
+		eventPrefix = "overlay"
+	}
+	reg = NewRegistry()
+
+	if *jwksURL != "" {
+		var err error
+		jwks, err = keyfunc.Get(*jwksURL, keyfunc.Options{RefreshInterval: time.Minute})
+		if err != nil {
+			log.Fatalf("load jwks: %v", err)
+		}
+	}
+
+	if _, err := bus.Connect(context.Background(), bus.Config{}); err != nil {
+		log.Printf("bus: %v", err)
+	}
+
+	go func() {
+		ticker := time.NewTicker(*ttl)
+		for range ticker.C {
+			reg.MarkStale(*ttl)
+		}
+	}()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("OK"))
+	})
+	mux.HandleFunc("/agents", agentsHandler)
+	mux.HandleFunc("/register", registerHandler)
+	mux.HandleFunc("/heartbeat", heartbeatHandler)
+
+	srv := &http.Server{
+		Addr:         *addr,
+		Handler:      mux,
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 5 * time.Second,
+	}
+
+	log.Printf("supervisor listening on %s", *addr)
+	log.Fatal(srv.ListenAndServe())
+}
+
+func agentsHandler(w http.ResponseWriter, r *http.Request) {
+	snap := reg.Snapshot()
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(snap)
+}
+
+func registerHandler(w http.ResponseWriter, r *http.Request) {
+	if err := auth(r); err != nil {
+		http.Error(w, err.Error(), http.StatusUnauthorized)
+		return
+	}
+	var a Agent
+	if err := json.NewDecoder(r.Body).Decode(&a); err != nil {
+		http.Error(w, "bad json", http.StatusBadRequest)
+		return
+	}
+	a.Status = "registered"
+	a.LastHeartbeat = time.Now()
+	reg.Upsert(a)
+	publishEvent("register", a)
+	w.WriteHeader(http.StatusOK)
+}
+
+func heartbeatHandler(w http.ResponseWriter, r *http.Request) {
+	if err := auth(r); err != nil {
+		http.Error(w, err.Error(), http.StatusUnauthorized)
+		return
+	}
+	var payload struct {
+		ID   string         `json:"id"`
+		Meta map[string]any `json:"meta,omitempty"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		http.Error(w, "bad json", http.StatusBadRequest)
+		return
+	}
+	reg.Heartbeat(payload.ID, payload.Meta)
+	publishEvent("heartbeat", Agent{ID: payload.ID})
+	w.WriteHeader(http.StatusOK)
+}
+
+func publishEvent(action string, a Agent) {
+	_ = bus.Publish(eventPrefix+"."+action, map[string]any{"action": action, "agent": a})
+}
+
+func auth(r *http.Request) error {
+	if jwks != nil {
+		token := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+		if token == "" {
+			return errors.New("missing token")
+		}
+		if _, err := jwt.Parse(token, jwks.Keyfunc); err != nil {
+			return err
+		}
+		return nil
+	}
+	if apiKey != "" {
+		if r.Header.Get("X-API-Key") != apiKey {
+			return errors.New("unauthorized")
+		}
+	}
+	return nil
+}

--- a/host/services/supervisor/cmd/supervisor/main_test.go
+++ b/host/services/supervisor/cmd/supervisor/main_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestRegisterHeartbeat(t *testing.T) {
+	reg = NewRegistry()
+	apiKey = ""
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/register", bytes.NewBufferString(`{"id":"a1"}`))
+	registerHandler(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("register status %d", rr.Code)
+	}
+	snap := reg.Snapshot()
+	if len(snap) != 1 || snap[0].Status != "registered" {
+		t.Fatalf("unexpected registry %+v", snap)
+	}
+
+	rr = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPost, "/heartbeat", bytes.NewBufferString(`{"id":"a1"}`))
+	heartbeatHandler(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("heartbeat status %d", rr.Code)
+	}
+	snap = reg.Snapshot()
+	if snap[0].Status != "healthy" {
+		t.Fatalf("expected healthy, got %s", snap[0].Status)
+	}
+
+	reg.MarkStale(time.Nanosecond)
+	snap = reg.Snapshot()
+	if snap[0].Status != "stale" {
+		t.Fatalf("expected stale, got %s", snap[0].Status)
+	}
+}

--- a/host/services/supervisor/go.mod
+++ b/host/services/supervisor/go.mod
@@ -1,0 +1,13 @@
+module github.com/Cdaprod/ThatDamToolbox/host/services/supervisor
+
+go 1.23.0
+
+toolchain go1.24.3
+
+require (
+	github.com/Cdaprod/ThatDamToolbox/host/services/shared v0.0.0-00010101000000-000000000000
+	github.com/MicahParks/keyfunc v1.5.2
+	github.com/golang-jwt/jwt/v4 v4.4.2
+)
+
+replace github.com/Cdaprod/ThatDamToolbox/host/services/shared => ../shared

--- a/host/services/supervisor/go.sum
+++ b/host/services/supervisor/go.sum
@@ -1,0 +1,4 @@
+github.com/MicahParks/keyfunc v1.5.2 h1:Ld/UbCEJ3hIn6RRWEQXCr6n/GCagaupbHIsV3K2ll2E=
+github.com/MicahParks/keyfunc v1.5.2/go.mod h1:IdnCilugA0O/99dW+/MkvlyrsX8+L8+x95xuVNtM5jw=
+github.com/golang-jwt/jwt/v4 v4.4.2 h1:rcc4lwaZgFMCZ5jxF9ABolDcIHdBytAFgqFPbSJQAYs=
+github.com/golang-jwt/jwt/v4 v4.4.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=


### PR DESCRIPTION
## Summary
- add optional supervisor service to track agent registrations and heartbeats
- provide shared Go client library for agents
- wire supervisor into docker-compose

## Testing
- `go test ./host/services/shared/supervisor ./host/services/supervisor/cmd/supervisor`

------
https://chatgpt.com/codex/tasks/task_e_689dd8fa64348326bfc164ad52cf40a9