### PR TITLE
feat: add switchable auth bridge

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -25,6 +25,56 @@ networks:
 
 services:
   ########################################################################
+  # Auth: Bridge (cloud/on-prem flip) + optional Keycloak
+  ########################################################################
+  auth-bridge:
+    build:
+      context: .
+      dockerfile: docker/auth-bridge/Dockerfile
+    image: cdaprod/auth-bridge:latest
+    container_name: thatdamtoolbox-auth
+    networks: [damnet]
+    ports: ["8081:8081"]
+    # Pick provider at runtime: "auth0" or "keycloak"
+    environment:
+      OIDC_PROVIDER: "${OIDC_PROVIDER:-auth0}"
+      # Auth0 defaults (ignored if provider=keycloak)
+      OIDC_ISSUER: "${AUTH0_ISSUER:-https://example.us.auth0.com/}"
+      OIDC_CLIENT_ID: "${AUTH0_CLIENT_ID:-changeme}"
+      OIDC_CLIENT_SECRET: "${AUTH0_CLIENT_SECRET:-changeme}"
+      OIDC_SCOPES: "openid profile email"
+      AUTH_REDIRECT_BASE: "${AUTH_REDIRECT_BASE:-http://localhost:8081}"
+      AUTH_COOKIE_DOMAIN: "${AUTH_COOKIE_DOMAIN:-localhost}"
+      AUTH_ALLOWED_ORIGINS: "${AUTH_ALLOWED_ORIGINS:-http://localhost:3000}"
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8081/health"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+    restart: unless-stopped
+    profiles: ["auth0","keycloak"]  # available in both profiles
+
+  keycloak:
+    image: quay.io/keycloak/keycloak:24.0
+    container_name: thatdamtoolbox-keycloak
+    networks: [damnet]
+    ports: ["8089:8080"]
+    environment:
+      KEYCLOAK_ADMIN: "admin"
+      KEYCLOAK_ADMIN_PASSWORD: "admin"
+    # Guard: only run when provider=keycloak (otherwise exit fast/no-op)
+    command: ["sh","-lc","[ \"$${OIDC_PROVIDER:-auth0}\" = keycloak ] || { echo 'Keycloak disabled'; exit 0; }; exec /opt/keycloak/bin/kc.sh start-dev --import-realm"]
+    volumes:
+      - ./seeds/keycloak:/opt/keycloak/data/import:ro
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8080/"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+    profiles: ["keycloak"]  # only appears when keycloak profile is active
+
+  ########################################################################
   # 0. one-shot host configurator (runs only with `--profile setup`)
   ########################################################################
   hotspot-installer:

--- a/docker/auth-bridge/Dockerfile
+++ b/docker/auth-bridge/Dockerfile
@@ -1,0 +1,23 @@
+# syntax=docker/dockerfile:1.5
+ARG GO_VERSION=1.23
+FROM golang:${GO_VERSION}-alpine AS builder
+WORKDIR /src
+
+# Copy minimal manifests for faster incremental builds
+COPY host/services/auth-bridge/go.mod host/services/auth-bridge/go.mod
+COPY host/services/auth-bridge/go.sum host/services/auth-bridge/go.sum
+RUN --mount=type=cache,target=/go/pkg/mod go mod download
+
+# Copy sources
+COPY host/services/auth-bridge/ host/services/auth-bridge/
+WORKDIR /src/host/services/auth-bridge
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 go build -o /out/auth-bridge ./cmd/auth-bridge
+
+FROM alpine:3.20
+RUN apk add --no-cache ca-certificates
+COPY --from=builder /out/auth-bridge /usr/local/bin/auth-bridge
+EXPOSE 8081
+ENTRYPOINT ["/usr/local/bin/auth-bridge"]
+

--- a/docker/compose/auth-auth0.yaml
+++ b/docker/compose/auth-auth0.yaml
@@ -1,0 +1,30 @@
+version: "3.9"
+name: thatdamtoolbox-auth-auth0
+services:
+  auth-bridge:
+    build:
+      context: .
+      dockerfile: docker/auth-bridge/Dockerfile
+    image: cdaprod/auth-bridge:latest
+    container_name: thatdamtoolbox-auth
+    networks: [damnet]
+    ports: ["8081:8081"]
+    environment:
+      OIDC_PROVIDER: "auth0"
+      OIDC_ISSUER: "${AUTH0_ISSUER:-https://example.us.auth0.com/}"
+      OIDC_CLIENT_ID: "${AUTH0_CLIENT_ID:-changeme}"
+      OIDC_CLIENT_SECRET: "${AUTH0_CLIENT_SECRET:-changeme}"
+      OIDC_SCOPES: "openid profile email"
+      AUTH_REDIRECT_BASE: "${AUTH_REDIRECT_BASE:-http://localhost:8081}"
+      AUTH_COOKIE_DOMAIN: "${AUTH_COOKIE_DOMAIN:-localhost}"
+      AUTH_ALLOWED_ORIGINS: "${AUTH_ALLOWED_ORIGINS:-http://localhost:3000}"
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8081/health"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+    restart: unless-stopped
+networks:
+  damnet:
+    external: true
+

--- a/docker/compose/auth-keycloak.yaml
+++ b/docker/compose/auth-keycloak.yaml
@@ -1,0 +1,51 @@
+version: "3.9"
+name: thatdamtoolbox-auth-keycloak
+services:
+  keycloak:
+    image: quay.io/keycloak/keycloak:24.0
+    container_name: thatdamtoolbox-keycloak
+    networks: [damnet]
+    ports: ["8089:8080"]
+    environment:
+      KEYCLOAK_ADMIN: "admin"
+      KEYCLOAK_ADMIN_PASSWORD: "admin"
+    command: ["start-dev","--import-realm"]
+    volumes:
+      - ./seeds/keycloak:/opt/keycloak/data/import:ro
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8080/"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
+  auth-bridge:
+    build:
+      context: .
+      dockerfile: docker/auth-bridge/Dockerfile
+    image: cdaprod/auth-bridge:latest
+    container_name: thatdamtoolbox-auth
+    networks: [damnet]
+    ports: ["8081:8081"]
+    environment:
+      OIDC_PROVIDER: "keycloak"
+      OIDC_ISSUER: "http://keycloak:8080/realms/thatdam"
+      OIDC_CLIENT_ID: "web-app"
+      OIDC_CLIENT_SECRET: ""
+      OIDC_SCOPES: "openid profile email"
+      AUTH_REDIRECT_BASE: "${AUTH_REDIRECT_BASE:-http://localhost:8081}"
+      AUTH_COOKIE_DOMAIN: "${AUTH_COOKIE_DOMAIN:-localhost}"
+      AUTH_ALLOWED_ORIGINS: "${AUTH_ALLOWED_ORIGINS:-http://localhost:3000}"
+    depends_on:
+      keycloak:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8081/health"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+    restart: unless-stopped
+networks:
+  damnet:
+    external: true
+

--- a/docs/TECHNICAL/AGENTS.md
+++ b/docs/TECHNICAL/AGENTS.md
@@ -18,6 +18,7 @@ This document explains the key principles and details you’ll need to develop a
 ## TOP OF MIND:
 
 - Avoid rewrites; wire new features into existing services.
+- auth-bridge flips between Auth0 and Keycloak; see `AUTH_FLIP.md`.
 - Architecture layers:
     – Host: Go services for device discovery, streaming, and proxying (capture-daemon, camera-proxy).
     – Backend: Python-based video-api and media modules.

--- a/docs/TECHNICAL/AUTH_FLIP.md
+++ b/docs/TECHNICAL/AUTH_FLIP.md
@@ -1,0 +1,36 @@
+# Auth Flip: Auth0 (cloud) ⇄ Keycloak (on-prem)
+
+## Quick Start
+
+### Auth0
+1) Create Application (Regular Web App).  
+2) Allowed Callback: `http://localhost:8081/callback`  
+3) Allowed Logout/Origins: `http://localhost:8081`, `http://localhost:3000`  
+4) Export:
+   - `AUTH0_ISSUER=https://<tenant>.us.auth0.com/`
+   - `AUTH0_CLIENT_ID=...`
+   - `AUTH0_CLIENT_SECRET=...`
+5) Run:
+```bash
+docker compose -f docker/compose/auth-auth0.yaml up --build
+```
+
+### Keycloak (offline/dev)
+1) Bring up seeded realm:
+```bash
+docker compose -f docker/compose/auth-keycloak.yaml up --build
+```
+2) Console: http://localhost:8089  (admin/admin)  
+   Realm: `thatdam`, Client: `web-app` (public + PKCE).  
+3) `auth-bridge` at http://localhost:8081
+
+## Service Contract (stable routes)
+- `GET /health`
+- `GET /login?next=/`
+- `GET /callback`
+- `POST /logout`
+- `GET /session/me`  → normalized `{sub,email,name,roles,org?,exp}`
+- Optional: `/.well-known/jwks.json` passthrough
+
+Flip providers by changing compose file and env; routes remain unchanged.
+

--- a/go.work
+++ b/go.work
@@ -1,12 +1,13 @@
 go 1.23.0
 
 use (
-	./host/services/api-gateway
-	./host/services/camera-proxy
-	./host/services/capture-daemon
-	./host/services/discovery
-	./host/services/media-api
-	./host/services/overlay-hub
+        ./host/services/api-gateway
+        ./host/services/camera-proxy
+        ./host/services/capture-daemon
+        ./host/services/discovery
+        ./host/services/auth-bridge
+        ./host/services/media-api
+        ./host/services/overlay-hub
         ./host/services/supervisor
         ./host/services/shared
         ./host/services/shared/hostcap/v4l2probe

--- a/host/services/auth-bridge/README.md
+++ b/host/services/auth-bridge/README.md
@@ -1,0 +1,13 @@
+# auth-bridge
+
+Minimal HTTP bridge exposing auth endpoints for Auth0 or Keycloak.
+
+## Usage
+```bash
+OIDC_PROVIDER=auth0 go run ./cmd/auth-bridge
+```
+
+## Testing
+```bash
+go test ./cmd/auth-bridge
+```

--- a/host/services/auth-bridge/cmd/auth-bridge/main.go
+++ b/host/services/auth-bridge/cmd/auth-bridge/main.go
@@ -1,0 +1,106 @@
+// Command auth-bridge provides a minimal OIDC bridge between Auth0 and
+// Keycloak.
+//
+// Usage:
+//
+//	OIDC_PROVIDER=auth0 go run ./cmd/auth-bridge
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"os"
+	"time"
+)
+
+// Minimal config (OIDC internals can be added later)
+type Config struct {
+	Provider       string
+	Issuer         string
+	ClientID       string
+	ClientSecret   string
+	Scopes         string
+	RedirectBase   string
+	CookieDomain   string
+	AllowedOrigins []string
+	Addr           string
+}
+
+func env(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+func loadConfig() Config {
+	return Config{
+		Provider:     env("OIDC_PROVIDER", "auth0"),
+		Issuer:       env("OIDC_ISSUER", ""),
+		ClientID:     env("OIDC_CLIENT_ID", ""),
+		ClientSecret: env("OIDC_CLIENT_SECRET", ""),
+		Scopes:       env("OIDC_SCOPES", "openid profile email"),
+		RedirectBase: env("AUTH_REDIRECT_BASE", "http://localhost:8081"),
+		CookieDomain: env("AUTH_COOKIE_DOMAIN", "localhost"),
+		Addr:         env("ADDR", ":8081"),
+	}
+}
+
+func main() {
+	cfg := loadConfig()
+	mux := buildMux(cfg)
+	srv := &http.Server{
+		Addr:              cfg.Addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	log.Printf("auth-bridge listening on %s (provider=%s issuer=%s)", cfg.Addr, cfg.Provider, cfg.Issuer)
+	log.Fatal(srv.ListenAndServe())
+}
+
+func buildMux(cfg Config) *http.ServeMux {
+	mux := http.NewServeMux()
+
+	// Health
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("OK"))
+	})
+
+	// Session (placeholder normalized profile)
+	mux.HandleFunc("/session/me", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		resp := map[string]any{
+			"sub":   "placeholder",
+			"email": "demo@example.com",
+			"name":  "Demo User",
+			"roles": []string{"viewer"},
+			"exp":   time.Now().Add(1 * time.Hour).Unix(),
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+
+	// Login/Callback/Logout stubs (safe to replace with real OIDC)
+	mux.HandleFunc("/login", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/", http.StatusFound)
+	})
+	mux.HandleFunc("/callback", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/", http.StatusFound)
+	})
+	mux.HandleFunc("/logout", func(w http.ResponseWriter, r *http.Request) {
+		http.SetCookie(w, &http.Cookie{
+			Name:     "thatdam_session",
+			Value:    "",
+			Path:     "/",
+			Domain:   cfg.CookieDomain,
+			MaxAge:   -1,
+			HttpOnly: true,
+			Secure:   false,
+			SameSite: http.SameSiteLaxMode,
+		})
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	return mux
+}

--- a/host/services/auth-bridge/cmd/auth-bridge/main_test.go
+++ b/host/services/auth-bridge/cmd/auth-bridge/main_test.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestHealthAndSession ensures basic endpoints respond.
+func TestHealthAndSession(t *testing.T) {
+	mux := buildMux(Config{CookieDomain: "localhost"})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	if resp, err := http.Get(srv.URL + "/health"); err != nil || resp.StatusCode != http.StatusOK {
+		t.Fatalf("health: %v status=%d", err, resp.StatusCode)
+	}
+
+	if resp, err := http.Get(srv.URL + "/session/me"); err != nil || resp.StatusCode != http.StatusOK {
+		t.Fatalf("session: %v status=%d", err, resp.StatusCode)
+	}
+}

--- a/host/services/auth-bridge/go.mod
+++ b/host/services/auth-bridge/go.mod
@@ -1,0 +1,3 @@
+module github.com/Cdaprod/ThatDamToolbox/host/services/auth-bridge
+
+go 1.23

--- a/seeds/keycloak/realm-thatdam.json
+++ b/seeds/keycloak/realm-thatdam.json
@@ -1,0 +1,24 @@
+{
+  "realm": "thatdam",
+  "enabled": true,
+  "clients": [
+    {
+      "clientId": "web-app",
+      "publicClient": true,
+      "redirectUris": ["http://localhost:8081/*","http://localhost:3000/*"],
+      "webOrigins": ["http://localhost:3000","http://localhost:8081"],
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "attributes": { "pkce.code.challenge.method": "S256" }
+    }
+  ],
+  "roles": {
+    "realm": [
+      {"name":"viewer"},
+      {"name":"operator"},
+      {"name":"admin"}
+    ]
+  }
+}
+


### PR DESCRIPTION
## Summary
- add auth-bridge Go service with stubbed auth endpoints
- wire docker builds and compose profiles for Auth0 or Keycloak
- document provider flip and service usage

## Testing
- `go test -v ./host/services/auth-bridge/cmd/auth-bridge`

## Checklist
- [x] Code is self-contained and idempotent.
- [x] No unnecessary new files or external dependencies.
- [x] Tests added or updated as appropriate.
- [x] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_689f394a0d988326a86ae9dacb8a452d