### PR TITLE
supervisor: add env policy port

### DIFF
--- a/host/services/supervisor/README.md
+++ b/host/services/supervisor/README.md
@@ -8,6 +8,14 @@ Control-plane service for agent registration, plans, and environment bootstrappi
 go run ./cmd/supervisor/main.go -addr :8070
 ```
 
+## Configuration
+
+- `POLICY_ALLOW_ANONYMOUS_PROXY`
+- `POLICY_REQUIRE_AUTH_FOR_PLAN`
+- `POLICY_REQUIRE_AUTH_FOR_BOOTSTRAP`
+- `JWKS_URL` (JWKS endpoint for JWT validation)
+- `SUPERVISOR_API_KEY` (static fallback)
+
 ## Endpoints (partial)
 
 - `POST /v1/nodes/register`

--- a/host/services/supervisor/cmd/supervisor/routes_handshake_test.go
+++ b/host/services/supervisor/cmd/supervisor/routes_handshake_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	envpolicy "github.com/Cdaprod/ThatDamToolbox/host/services/supervisor/internal/policy/envpolicy"
+)
+
+func TestNodesRegisterPolicy(t *testing.T) {
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/nodes/register", nil)
+
+	policy = envpolicy.EnvPolicy{AllowAnonymousProxy: false}
+	nodesRegister(rr, req)
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", rr.Code)
+	}
+
+	rr = httptest.NewRecorder()
+	policy = envpolicy.EnvPolicy{AllowAnonymousProxy: true}
+	nodesRegister(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+}

--- a/host/services/supervisor/internal/policy/envpolicy/envpolicy.go
+++ b/host/services/supervisor/internal/policy/envpolicy/envpolicy.go
@@ -1,0 +1,72 @@
+// Package envpolicy provides an environment-driven Policy implementation.
+package envpolicy
+
+import (
+	"context"
+	"os"
+	"strconv"
+
+	"github.com/Cdaprod/ThatDamToolbox/host/services/supervisor/internal/ports"
+)
+
+// EnvPolicy implements ports.Policy using environment variables for simple feature flags.
+type EnvPolicy struct {
+	AllowAnonymousProxy     bool
+	RequireAuthForPlan      bool
+	RequireAuthForBootstrap bool
+}
+
+// NewFromEnv builds an EnvPolicy from environment variables.
+// Example:
+//
+//	POLICY_ALLOW_ANONYMOUS_PROXY=1 supervisor
+func NewFromEnv() EnvPolicy {
+	return EnvPolicy{
+		AllowAnonymousProxy:     getBool("POLICY_ALLOW_ANONYMOUS_PROXY"),
+		RequireAuthForPlan:      getBool("POLICY_REQUIRE_AUTH_FOR_PLAN"),
+		RequireAuthForBootstrap: getBool("POLICY_REQUIRE_AUTH_FOR_BOOTSTRAP"),
+	}
+}
+
+func getBool(k string) bool {
+	v, _ := strconv.ParseBool(os.Getenv(k))
+	return v
+}
+
+// Allow decides if the principal may perform the given action.
+func (e EnvPolicy) Allow(_ context.Context, p ports.Principal, a ports.Action) bool {
+	// Unauthenticated principals
+	if p.Sub == "" {
+		switch a {
+		case ports.ActPlan:
+			return !e.RequireAuthForPlan
+		case ports.ActRegister:
+			return e.AllowAnonymousProxy
+		default:
+			return false
+		}
+	}
+	switch a {
+	case ports.ActRegister, ports.ActHeartbeat:
+		return p.Scopes["thatdam:register"]
+	case ports.ActPlan:
+		return p.Scopes["thatdam:read"]
+	case ports.ActBootstrap:
+		if e.RequireAuthForBootstrap {
+			return p.Scopes["thatdam:apply"]
+		}
+		return true
+	case ports.ActLeader:
+		return p.Scopes["thatdam:admin"]
+	default:
+		return false
+	}
+}
+
+// Flags exposes feature flags relevant to plan shaping.
+func (e EnvPolicy) Flags(_ context.Context) map[string]bool {
+	return map[string]bool{
+		"allowAnonymousProxy": e.AllowAnonymousProxy,
+		"requireAuthForPlan":  e.RequireAuthForPlan,
+	}
+}

--- a/host/services/supervisor/internal/policy/envpolicy/envpolicy_test.go
+++ b/host/services/supervisor/internal/policy/envpolicy/envpolicy_test.go
@@ -1,0 +1,27 @@
+package envpolicy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Cdaprod/ThatDamToolbox/host/services/supervisor/internal/ports"
+)
+
+// Test Allow logic for anonymous and scoped principals.
+func TestEnvPolicyAllow(t *testing.T) {
+	p := EnvPolicy{AllowAnonymousProxy: true}
+	if !p.Allow(context.Background(), ports.Principal{}, ports.ActRegister) {
+		t.Fatal("anonymous register should be allowed")
+	}
+	if !p.Allow(context.Background(), ports.Principal{}, ports.ActPlan) {
+		t.Fatal("anonymous plan should be allowed when auth not required")
+	}
+	p.RequireAuthForPlan = true
+	if p.Allow(context.Background(), ports.Principal{}, ports.ActPlan) {
+		t.Fatal("anonymous plan should be denied when auth required")
+	}
+	authP := ports.Principal{Sub: "n1", Scopes: map[string]bool{"thatdam:read": true}}
+	if !p.Allow(context.Background(), authP, ports.ActPlan) {
+		t.Fatal("scoped principal should be allowed")
+	}
+}

--- a/host/services/supervisor/internal/ports/policy.go
+++ b/host/services/supervisor/internal/ports/policy.go
@@ -1,0 +1,28 @@
+// Package ports defines interfaces for supervisor dependencies.
+package ports
+
+import "context"
+
+// Principal represents an authenticated subject with granted scopes and roles.
+type Principal struct {
+	Sub    string
+	Scopes map[string]bool
+	Roles  []string
+}
+
+// Action enumerates operations that require authorization checks.
+type Action string
+
+const (
+	ActRegister  Action = "register"
+	ActPlan      Action = "plan.read"
+	ActHeartbeat Action = "heartbeat"
+	ActBootstrap Action = "bootstrap.apply"
+	ActLeader    Action = "leader.claim"
+)
+
+// Policy decides if a principal may perform an action and exposes feature flags.
+type Policy interface {
+	Allow(ctx context.Context, p Principal, a Action) bool
+	Flags(ctx context.Context) map[string]bool
+}


### PR DESCRIPTION
## Summary
- add policy port and env-based implementation
- enforce policy in supervisor handshake routes
- document policy configuration and tests

## Testing
- `go test ./host/services/supervisor/... -run Test -count=1`

## Checklist
- [x] Code is self-contained and idempotent.
- [x] No unnecessary new files or external dependencies.
- [x] Tests added or updated as appropriate.
- [x] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_689f580bfddc8326bab366660b1e731c