### PR TITLE
discovery: scaffold bootstrap adapters and apply

### DIFF
--- a/host/services/discovery/internal/bootstrap/adapters.go
+++ b/host/services/discovery/internal/bootstrap/adapters.go
@@ -1,0 +1,48 @@
+package bootstrap
+
+import (
+	"context"
+	"os"
+
+	runtimedocker "github.com/Cdaprod/ThatDamToolbox/host/services/shared/bootstrap/adapters/runtime_docker"
+	runtimeexec "github.com/Cdaprod/ThatDamToolbox/host/services/shared/bootstrap/adapters/runtime_exec"
+	runtimens "github.com/Cdaprod/ThatDamToolbox/host/services/shared/bootstrap/adapters/runtime_ns"
+	ports "github.com/Cdaprod/ThatDamToolbox/host/services/shared/bootstrap/ports"
+)
+
+// Adapters bundles dependencies used during bootstrap.
+//
+// Example:
+//
+//	adapters, err := NewAdapters(context.Background())
+//	if err != nil {
+//	    // handle error
+//	}
+type Adapters struct {
+	Storage interface{}
+	Bus     interface{}
+	Index   interface{}
+	Runtime ports.ServiceRuntime
+}
+
+// NewAdapters selects bootstrap adapters based on environment variables.
+func NewAdapters(ctx context.Context) (Adapters, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return Adapters{Runtime: ChooseRuntime()}, nil
+}
+
+// ChooseRuntime selects a ServiceRuntime based on the host environment.
+//
+// It prefers Docker if the docker socket is present, then a namespace runtime
+// if NS_ROOTFS is set, and finally falls back to a simple exec-based runtime.
+func ChooseRuntime() ports.ServiceRuntime {
+	if _, err := os.Stat("/var/run/docker.sock"); err == nil {
+		return runtimedocker.New("")
+	}
+	if root := os.Getenv("NS_ROOTFS"); root != "" {
+		return runtimens.New(root)
+	}
+	return runtimeexec.New()
+}

--- a/host/services/discovery/internal/bootstrap/apply.go
+++ b/host/services/discovery/internal/bootstrap/apply.go
@@ -1,0 +1,36 @@
+package bootstrap
+
+import (
+	"context"
+	"errors"
+)
+
+// Engine applies a bootstrap profile to the local node.
+//
+// Any type implementing Apply can be used, allowing callers to pass
+// concrete reconcilers.
+type Engine interface {
+	Apply(ctx context.Context, profile any) error
+}
+
+// Apply reconciles the given profile using the supplied engine.
+//
+// Example:
+//
+//	err := Apply(context.Background(), engine, profile)
+//	if err != nil {
+//	    // handle error
+//	}
+//
+// A nil engine returns an error. The profile parameter is intentionally
+// untyped so that this package remains decoupled from specific profile
+// definitions.
+func Apply(ctx context.Context, eng Engine, profile any) error {
+	if eng == nil {
+		return errors.New("engine is nil")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return eng.Apply(ctx, profile)
+}

--- a/host/services/discovery/internal/bootstrap/bootstrap_test.go
+++ b/host/services/discovery/internal/bootstrap/bootstrap_test.go
@@ -1,0 +1,60 @@
+package bootstrap
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+type mockEngine struct {
+	profile any
+	err     error
+	called  bool
+}
+
+func (m *mockEngine) Apply(ctx context.Context, profile any) error {
+	m.called = true
+	m.profile = profile
+	return m.err
+}
+
+func TestApplyRequiresEngine(t *testing.T) {
+	if err := Apply(context.Background(), nil, nil); err == nil {
+		t.Fatal("expected error when engine is nil")
+	}
+}
+
+func TestApplyDelegatesToEngine(t *testing.T) {
+	m := &mockEngine{}
+	prof := struct{ Name string }{"test"}
+	if err := Apply(context.Background(), m, prof); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !m.called || m.profile != prof {
+		t.Fatalf("engine not called with profile: %+v", m.profile)
+	}
+}
+
+func TestApplyPropagatesError(t *testing.T) {
+	want := errors.New("boom")
+	m := &mockEngine{err: want}
+	if err := Apply(context.Background(), m, nil); !errors.Is(err, want) {
+		t.Fatalf("expected %v, got %v", want, err)
+	}
+}
+
+func TestNewAdaptersIncludesRuntime(t *testing.T) {
+	adapters, err := NewAdapters(context.Background())
+	if err != nil {
+		t.Fatalf("NewAdapters returned error: %v", err)
+	}
+	if adapters.Runtime == nil {
+		t.Fatalf("expected runtime adapter")
+	}
+}
+
+func TestChooseRuntime(t *testing.T) {
+	if rt := ChooseRuntime(); rt == nil {
+		t.Fatalf("expected non-nil runtime")
+	}
+}

--- a/host/services/shared/bootstrap/adapters/runtime_docker/docker.go
+++ b/host/services/shared/bootstrap/adapters/runtime_docker/docker.go
@@ -1,0 +1,45 @@
+package runtimedocker
+
+import (
+	"context"
+	"os/exec"
+
+	ports "github.com/Cdaprod/ThatDamToolbox/host/services/shared/bootstrap/ports"
+)
+
+// DockerRuntime manages services using the Docker CLI.
+//
+// Example:
+//
+//	rt := runtimedocker.New("")
+//	_ = rt.Ensure(ctx, ports.UnitSpec{Name: "busy", Command: []string{"busybox", "true"}})
+type DockerRuntime struct{ Bin string }
+
+// New returns a DockerRuntime using the provided binary name.
+func New(bin string) DockerRuntime {
+	if bin == "" {
+		bin = "docker"
+	}
+	return DockerRuntime{Bin: bin}
+}
+
+// Ensure runs the container using `docker run --rm` semantics.
+func (d DockerRuntime) Ensure(ctx context.Context, u ports.UnitSpec) error {
+	if len(u.Command) == 0 {
+		return nil
+	}
+	args := append([]string{"run", "--rm", "-d", "--name", u.Name}, u.Command...)
+	cmd := exec.CommandContext(ctx, d.Bin, args...)
+	return cmd.Run()
+}
+
+// Stop removes the named container if present.
+func (d DockerRuntime) Stop(ctx context.Context, name string) error {
+	exec.CommandContext(ctx, d.Bin, "rm", "-f", name).Run()
+	return nil
+}
+
+// State always reports the unit as inactive. Detailed inspection is TODO.
+func (d DockerRuntime) State(ctx context.Context, name string) (ports.UnitState, error) {
+	return ports.UnitState{Name: name, Active: false}, nil
+}

--- a/host/services/shared/bootstrap/adapters/runtime_exec/exec.go
+++ b/host/services/shared/bootstrap/adapters/runtime_exec/exec.go
@@ -1,0 +1,46 @@
+package runtimeexec
+
+import (
+	"context"
+	"os/exec"
+
+	ports "github.com/Cdaprod/ThatDamToolbox/host/services/shared/bootstrap/ports"
+)
+
+// ExecRuntime starts services as local processes.
+//
+// Example:
+//
+//	rt := runtimeexec.New()
+//	_ = rt.Ensure(ctx, ports.UnitSpec{Name: "sleep", Command: []string{"sleep", "1"}})
+type ExecRuntime struct{}
+
+// New creates a new ExecRuntime.
+func New() ExecRuntime { return ExecRuntime{} }
+
+// Ensure starts the process described by the unit specification.
+// It returns once the command has been started.
+func (ExecRuntime) Ensure(ctx context.Context, u ports.UnitSpec) error {
+	if len(u.Command) == 0 {
+		return nil
+	}
+	cmd := exec.CommandContext(ctx, u.Command[0], u.Command[1:]...)
+	cmd.Env = append(cmd.Env, formatEnv(u.Env)...)
+	return cmd.Start()
+}
+
+// Stop is a no-op for ExecRuntime since processes are not tracked.
+func (ExecRuntime) Stop(ctx context.Context, name string) error { return nil }
+
+// State always reports the unit as inactive because processes are not tracked.
+func (ExecRuntime) State(ctx context.Context, name string) (ports.UnitState, error) {
+	return ports.UnitState{Name: name, Active: false}, nil
+}
+
+func formatEnv(m map[string]string) []string {
+	env := make([]string, 0, len(m))
+	for k, v := range m {
+		env = append(env, k+"="+v)
+	}
+	return env
+}

--- a/host/services/shared/bootstrap/adapters/runtime_ns/ns.go
+++ b/host/services/shared/bootstrap/adapters/runtime_ns/ns.go
@@ -1,0 +1,26 @@
+//go:build linux
+
+package runtimens
+
+import (
+	"context"
+
+	ports "github.com/Cdaprod/ThatDamToolbox/host/services/shared/bootstrap/ports"
+)
+
+// NSRuntime is a placeholder for namespace based isolation.
+type NSRuntime struct{ Rootfs string }
+
+// New creates a new NSRuntime.
+func New(rootfs string) NSRuntime { return NSRuntime{Rootfs: rootfs} }
+
+// Ensure currently does nothing and succeeds.
+func (NSRuntime) Ensure(ctx context.Context, u ports.UnitSpec) error { return nil }
+
+// Stop currently does nothing and succeeds.
+func (NSRuntime) Stop(ctx context.Context, name string) error { return nil }
+
+// State reports the unit as inactive.
+func (NSRuntime) State(ctx context.Context, name string) (ports.UnitState, error) {
+	return ports.UnitState{Name: name, Active: false}, nil
+}

--- a/host/services/shared/bootstrap/ports/runtime.go
+++ b/host/services/shared/bootstrap/ports/runtime.go
@@ -1,0 +1,35 @@
+package ports
+
+import "context"
+
+// UnitSpec describes a service unit to run on a node.
+//
+// Example:
+//
+//	spec := ports.UnitSpec{Name: "echo", Command: []string{"echo", "hi"}}
+//
+// This specification can be passed to a ServiceRuntime to ensure the
+// service is running.
+type UnitSpec struct {
+	Name    string            // logical name of the unit
+	Command []string          // command and args
+	Env     map[string]string // environment variables
+}
+
+// UnitState reports the status of a service unit.
+type UnitState struct {
+	Name    string
+	Active  bool
+	Pid     int
+	Message string
+}
+
+// ServiceRuntime abstracts how node services are managed.
+//
+// Implementations should be idempotent. Calling Ensure multiple times with
+// the same UnitSpec must have the same effect.
+type ServiceRuntime interface {
+	Ensure(ctx context.Context, u UnitSpec) error
+	Stop(ctx context.Context, name string) error
+	State(ctx context.Context, name string) (UnitState, error)
+}


### PR DESCRIPTION
## Summary
- scaffold discovery bootstrap package
- add adapter selection and apply stubs
- cover new code with unit tests
- introduce runtime port and adapters for docker, namespace, and exec
- select runtime adapter during discovery bootstrap setup

## Testing
- `go test ./host/services/discovery/... ./host/services/shared/bootstrap/...`

## Checklist
- [x] Code is self-contained and idempotent.
- [x] No unnecessary new files or external dependencies.
- [x] Tests added or updated as appropriate.
- [x] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_689f73493eb88326aaa27976cbb052b6