### PR TITLE
Refactor discovery service into internal manager and cmd entrypoint

### DIFF
--- a/host/services/discovery/README.md
+++ b/host/services/discovery/README.md
@@ -4,6 +4,17 @@
 
 This discovery service intelligently determines whether to become a “central server” (running capture-daemon + all infrastructure) or a “camera-proxy” (connecting to existing server) based on network environment discovery.
 
+### Development
+
+```bash
+# run service
+go run ./cmd/discovery
+
+# run tests
+go test ./...
+```
+
+
 ### Logging
 
 The service uses a shared logger configured via environment variables:

--- a/host/services/discovery/cmd/discovery/main.go
+++ b/host/services/discovery/cmd/discovery/main.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"os"
+	"time"
+
+	"github.com/Cdaprod/ThatDAMToolbox/host/services/discovery/internal/manager"
+	"github.com/Cdaprod/ThatDamToolbox/host/services/shared/logx"
+)
+
+// main is the discovery service entrypoint.
+// Example: go run ./host/services/discovery
+func main() {
+	logx.Init(logx.Config{
+		Service: "discovery",
+		Version: manager.Version,
+		Level:   getEnv("LOG_LEVEL", "info"),
+		Format:  getEnv("LOG_FORMAT", "auto"),
+		Caller:  getEnv("LOG_CALLER", "short"),
+		Time:    getEnv("LOG_TIME", "rfc3339ms"),
+		NoColor: os.Getenv("LOG_NO_COLOR") == "1",
+	})
+
+	dm := manager.New()
+
+	go func() {
+		time.Sleep(time.Hour)
+		dm.Stop()
+	}()
+
+	if err := dm.Start(); err != nil {
+		logx.L.Error("failed to start discovery service", "err", err)
+		os.Exit(1)
+	}
+
+	select {}
+}
+
+func getEnv(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}

--- a/host/services/discovery/internal/handshake/handshake.go
+++ b/host/services/discovery/internal/handshake/handshake.go
@@ -1,4 +1,4 @@
-package main
+package handshake
 
 import (
 	"context"

--- a/host/services/discovery/internal/manager/manager.go
+++ b/host/services/discovery/internal/manager/manager.go
@@ -1,4 +1,4 @@
-package main
+package manager
 
 import (
 	"context"
@@ -32,7 +32,7 @@ const (
 	DiscoveryTailscale = "tailscale"
 )
 
-var version = "dev"
+const Version = "dev"
 
 type ServiceInfo struct {
 	Host     string    `json:"host"`
@@ -60,7 +60,7 @@ type DiscoveryManager struct {
 	healthServer *http.Server
 }
 
-func NewDiscoveryManager() *DiscoveryManager {
+func New() *DiscoveryManager {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	// Generate unique node ID
@@ -558,40 +558,4 @@ func printBanner() {
 🌐 Enterprise-grade auto-discovery for PaaS/IaaS/SaaS deployment
 `
 	fmt.Println(banner)
-}
-
-func main() {
-	logx.Init(logx.Config{
-		Service: "discovery",
-		Version: version,
-		Level:   getEnv("LOG_LEVEL", "info"),
-		Format:  getEnv("LOG_FORMAT", "auto"),
-		Caller:  getEnv("LOG_CALLER", "short"),
-		Time:    getEnv("LOG_TIME", "rfc3339ms"),
-		NoColor: os.Getenv("LOG_NO_COLOR") == "1",
-	})
-
-	dm := NewDiscoveryManager()
-
-	// Graceful shutdown handling
-	go func() {
-		// In a real implementation, you'd handle SIGINT/SIGTERM here
-		time.Sleep(time.Hour) // Placeholder - run for an hour
-		dm.Stop()
-	}()
-
-	if err := dm.Start(); err != nil {
-		logx.L.Error("failed to start discovery service", "err", err)
-		os.Exit(1)
-	}
-
-	// Keep running
-	select {}
-}
-
-func getEnv(key, def string) string {
-	if v := os.Getenv(key); v != "" {
-		return v
-	}
-	return def
 }

--- a/host/services/discovery/internal/manager/manager_test.go
+++ b/host/services/discovery/internal/manager/manager_test.go
@@ -1,4 +1,4 @@
-package main
+package manager
 
 import (
 	"os"
@@ -9,7 +9,7 @@ import (
 func TestDetectDiscoveryBackendDefault(t *testing.T) {
 	os.Unsetenv("SERF_JOIN")
 	os.Unsetenv("DISCOVERY_BACKEND")
-	dm := NewDiscoveryManager()
+	dm := New()
 	if got := dm.detectDiscoveryBackend(); got != DiscoveryMDNS {
 		t.Fatalf("expected %s, got %s", DiscoveryMDNS, got)
 	}
@@ -19,7 +19,7 @@ func TestDetectDiscoveryBackendDefault(t *testing.T) {
 func TestDetectDiscoveryBackendOverride(t *testing.T) {
 	os.Setenv("DISCOVERY_BACKEND", "serf")
 	t.Cleanup(func() { os.Unsetenv("DISCOVERY_BACKEND") })
-	dm := NewDiscoveryManager()
+	dm := New()
 	if got := dm.detectDiscoveryBackend(); got != DiscoverySerf {
 		t.Fatalf("expected %s, got %s", DiscoverySerf, got)
 	}


### PR DESCRIPTION
## Summary
- extract discovery logic into internal manager package
- add cmd/discovery entrypoint and move handshake stubs into internal package
- document development run and test commands in README

## Testing
- `go test ./host/services/discovery/...`

## Checklist
- [x] Code is self-contained and idempotent.
- [x] No unnecessary new files or external dependencies.
- [x] Tests added or updated as appropriate.
- [x] Docs updated where needed.

------
https://chatgpt.com/codex/tasks/task_e_689fd794780083268dfe6a5d895f9717