### PR TITLE
Fix build context for Go services

### DIFF
--- a/README.md
+++ b/README.md
@@ -740,8 +740,11 @@ release binaries, and installs them to `/usr/local/bin`.
 git clone https://github.com/Cdaprod/ThatDAMToolbox.git
 cd ThatDAMToolbox
 
+# Build Go service images (run from repo root)
+docker compose build overlay-hub supervisor runner
+
 # Build and run with Docker Compose
-docker-compose up -d
+docker compose up -d
 
 # Access the web interface
 open http://localhost:8080

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -254,8 +254,8 @@ services:
   ########################################################################
   overlay-hub:
     build:
-      context: host/services/overlay-hub
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: host/services/overlay-hub/Dockerfile
     image: cdaprod/overlay-hub:${IMAGE_TAG:-dev}
     container_name: thatdamtoolbox-overlay-hub
     networks: [damnet]
@@ -283,8 +283,8 @@ services:
 
   supervisor:
     build:
-      context: host/services/supervisor
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: host/services/supervisor/Dockerfile
     image: cdaprod/supervisor:${IMAGE_TAG:-dev}
     container_name: thatdamtoolbox-supervisor
     networks: [damnet]
@@ -304,8 +304,8 @@ services:
 
   runner:
     build:
-      context: host/services/runner
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: host/services/runner/Dockerfile
     image: cdaprod/runner:${IMAGE_TAG:-dev}
     container_name: thatdamtoolbox-runner
     networks: [damnet]


### PR DESCRIPTION
## Summary
- point Go services to use repository root as build context so shared module files are available
- document building Go service images from repo root

## Testing
- ⚠️ `docker compose build overlay-hub supervisor runner` *(docker compose plugin unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_689fde67ab848326bf43220541b641ee