### PR TITLE
fix: remove network override to prevent compose collisions

### DIFF
--- a/docker/compose/auth-auth0.yaml
+++ b/docker/compose/auth-auth0.yaml
@@ -23,7 +23,4 @@ services:
       timeout: 3s
       retries: 5
     restart: unless-stopped
-networks:
-  damnet:
-    external: true
 

--- a/docker/compose/auth-keycloak.yaml
+++ b/docker/compose/auth-keycloak.yaml
@@ -44,7 +44,4 @@ services:
       timeout: 3s
       retries: 5
     restart: unless-stopped
-networks:
-  damnet:
-    external: true
 


### PR DESCRIPTION
## Summary
- remove duplicate `damnet` network declarations from auth provider compose snippets
- rely on root network definition to avoid `docker compose` conflicts

## Testing
- `go test -v ./host/services/auth-bridge/cmd/auth-bridge`

## Checklist
- [x] Code is self-contained and idempotent.
- [x] No unnecessary new files or external dependencies.
- [x] Tests added or updated as appropriate.
- [x] Docs updated where needed.

------
https://chatgpt.com/codex/tasks/task_e_68a10192df9c8326ba50aede6ae95d30