### PR TITLE
Handle bus adapter absence and refine startup parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -783,6 +783,16 @@ recent_media = indexer.get_recent()
 results = indexer.search("sunset beach")
 ```
 
+### Upstream Configuration
+
+Set `UPSTREAM` to a `host:port` pair so services know where to reach the API gateway:
+
+```bash
+export UPSTREAM=api-gateway:8080
+```
+
+The entrypoint automatically splits this into `UPSTREAM_HOST` and `UPSTREAM_PORT`.
+
 ### Web Interface
 
 1. Navigate to `http://localhost:8080`

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,6 +9,12 @@ if [ -f /opt/shared/entrypoint-snippet.sh ]; then
   . /opt/shared/entrypoint-snippet.sh
 fi
 
+# Derive UPSTREAM_HOST and UPSTREAM_PORT from UPSTREAM if not already set
+if [[ -z "${UPSTREAM_HOST:-}" && -n "${UPSTREAM:-}" ]]; then
+  IFS=':' read -r UPSTREAM_HOST UPSTREAM_PORT <<< "${UPSTREAM}"
+  export UPSTREAM_HOST UPSTREAM_PORT
+fi
+
 if [ "${ROLE:-server}" = "agent" ]; then
   export EVENT_BROKER_URL="${EVENT_BROKER_URL:-amqp://video:video@${UPSTREAM_HOST}:${UPSTREAM_PORT:-5672}/}"
   UPSTREAM_ARG=(--upstream "http://${UPSTREAM_HOST}:${UPSTREAM_PORT:-8080}")

--- a/host/services/discovery/entrypoint-snippet.sh
+++ b/host/services/discovery/entrypoint-snippet.sh
@@ -1,8 +1,14 @@
-# Source leader env if discovery is running (same volume or host path)
-/path/to/your/app/entrypoint.sh
+# discovery/entrypoint-snippet.sh
+#
+# Sources discovery leader information if present and exports
+# UPSTREAM_HOST and UPSTREAM_PORT for consumers.
+#
+# Example:
+#   . /opt/shared/entrypoint-snippet.sh
+
 if [ -f "${LEADER_FILE:-/run/discovery/leader.env}" ]; then
+  # shellcheck disable=SC1090
   . "${LEADER_FILE:-/run/discovery/leader.env}"
   export UPSTREAM_HOST UPSTREAM_PORT
 fi
 
-# If we’re the server role, bind to SERVICE_PORT; otherwise point to UPSTREAM_*

--- a/host/services/discovery/internal/manager/manager_test.go
+++ b/host/services/discovery/internal/manager/manager_test.go
@@ -24,3 +24,13 @@ func TestDetectDiscoveryBackendOverride(t *testing.T) {
 		t.Fatalf("expected %s, got %s", DiscoverySerf, got)
 	}
 }
+
+// TestComposeCmdMissing ensures a clear error when docker-compose is not found.
+func TestComposeCmdMissing(t *testing.T) {
+	orig := os.Getenv("PATH")
+	os.Setenv("PATH", "")
+	t.Cleanup(func() { os.Setenv("PATH", orig) })
+	if _, err := composeCmd("up"); err == nil {
+		t.Fatalf("expected error when docker-compose is missing")
+	}
+}

--- a/host/services/shared/bus/facade.go
+++ b/host/services/shared/bus/facade.go
@@ -58,6 +58,10 @@ func Connect(ctx context.Context, cfg Config) (Bus, error) {
 			instErr = errors.New("bus: missing exchange")
 			return
 		}
+		if adapterCtor == nil {
+			instErr = errors.New("bus: no adapter registered")
+			return
+		}
 		var err error
 		inst, err = adapterCtor(cfg)
 		if err != nil {

--- a/host/services/shared/bus/facade_test.go
+++ b/host/services/shared/bus/facade_test.go
@@ -34,10 +34,16 @@ func (m *mockBus) Subscribe(topic string, fn func([]byte)) error {
 
 func (m *mockBus) Close() error { return nil }
 
-func TestPublishSubscribe(t *testing.T) {
-	adapterCtor = newMockBus
-	defer func() { adapterCtor = nil }()
+func reset() {
+	once = sync.Once{}
+	inst = nil
+	instErr = nil
+	adapterCtor = nil
+}
 
+func TestPublishSubscribe(t *testing.T) {
+	reset()
+	adapterCtor = newMockBus
 	cfg := Config{URL: "amqp://test", Exchange: "events"}
 	if _, err := Connect(context.Background(), cfg); err != nil {
 		t.Fatalf("connect: %v", err)
@@ -58,5 +64,13 @@ func TestPublishSubscribe(t *testing.T) {
 		}
 	default:
 		t.Fatal("no message")
+	}
+}
+
+func TestConnectNoAdapter(t *testing.T) {
+	reset()
+	cfg := Config{URL: "amqp://test", Exchange: "events"}
+	if _, err := Connect(context.Background(), cfg); err == nil {
+		t.Fatal("expected error when no adapter registered")
 	}
 }


### PR DESCRIPTION
## Summary
- prevent `bus.Connect` panic when no adapter is registered
- parse `UPSTREAM=host:port` in entrypoint and document expected format
- clean discovery entrypoint snippet and check for docker-compose presence

## Testing
- `go test ./host/services/shared/bus`
- `go test ./host/services/discovery/internal/manager`

## Checklist
- [ ] Code is self-contained and idempotent.
- [ ] No unnecessary new files or external dependencies.
- [ ] Tests added or updated as appropriate.
- [ ] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_68a25562b77083268ba47b7825a81b37