### PR TITLE
chore: configure RabbitMQ disk space

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,6 +157,7 @@ host/releases/
 !/docker/web-app/tsconfig.json
 !/docker/web-app/tsconfig.test.json
 !/docker/rabbitmq/definitions.json
+docker/rabbitmq/data/
 !/docker/weaviate/schema.json
 !/docker/proxy-viewer/package.json
 !/docker/proxy-viewer/tsconfig.json

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -152,6 +152,7 @@ services:
       RABBITMQ_DEFAULT_USER: video
       RABBITMQ_DEFAULT_PASS: video
       RABBITMQ_DEFAULT_VHOST: /
+      RABBITMQ_DISK_FREE_LIMIT: 50MB
     ports: ["5672:5672", "15672:15672"]   # 15672 optional (management UI)
     volumes:
       - rabbitmq_data:/var/lib/rabbitmq
@@ -599,5 +600,10 @@ volumes:
   db_wal:
     driver: local
   rabbitmq_data:
+    driver: local
+    driver_opts:
+      type: none
+      o: bind
+      device: ${RABBITMQ_DATA_PATH:-./docker/rabbitmq/data}
   discovery-run:
     name: ${COMPOSE_PROJECT_NAME:-thatdamtoolbox}_discovery-run


### PR DESCRIPTION
## Summary
- set minimum free disk limit for RabbitMQ
- bind RabbitMQ data volume to configurable host path
- ignore RabbitMQ data directory in git

## Testing
- `python -m pytest tests/test_api.py` *(fails: Command '['stat', '-f', '-c', '%T', '/data/db']' returned non-zero exit status 1)*

## Checklist
- [x] Code is self-contained and idempotent.
- [x] No unnecessary new files or external dependencies.
- [ ] Tests added or updated as appropriate.
- [ ] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_68a4a1e8c5608326b6cb863b2ccd680e