### PR TITLE
Switch gateway to damnet network with port mapping

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -104,7 +104,8 @@ services:
     image: cdaprod/gateway:latest
     container_name: thatdamtoolbox-gateway
     entrypoint: ["/bin/bash","-lc",". /opt/shared/entrypoint-snippet.sh && exec /entrypoint.sh"]
-    network_mode: host             # owns :80 / :443 on the Pi
+    networks: [damnet]
+    ports: ["80:80"]
     restart: unless-stopped
     depends_on:
       - api-gateway
@@ -116,9 +117,6 @@ services:
       UPSTREAM_PORT: "8080"
       UPSTREAM: api-gateway:8080
       SERVICE_PORT: "8080"
-    # If you choose bridge mode instead, comment network_mode and add:
-    # networks: [damnet]
-    # ports: ["80:80"]
     volumes:
       - ./host/services/shared/entrypoint-snippet.sh:/opt/shared/entrypoint-snippet.sh:ro
       - ./docker/nginx/entrypoint.sh:/entrypoint.sh:ro


### PR DESCRIPTION
## Summary
- move gateway service to damnet bridge network
- expose port 80 to retain external access

## Testing
- `docker compose config` *(fails: command not found: docker)*

## Checklist
- [x] Code is self-contained and idempotent.
- [x] No unnecessary new files or external dependencies.
- [x] Tests added or updated as appropriate.
- [x] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_68a4a1d831488326882ed0f197e65f86