### PR TITLE
Ensure Weaviate waits for MinIO and Postgres health and track data volumes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ dist/
 *.tar
 *.tar.gz
 data/
+!/docker/weaviate/data/
 
 # ---- Metadata/output folders ----
 /metadata/

--- a/docker/compose/docker-compose.weaviate.yaml
+++ b/docker/compose/docker-compose.weaviate.yaml
@@ -35,8 +35,10 @@ services:
     volumes:
       - ./docker/weaviate/data/weaviate:/var/lib/weaviate
     depends_on:
-      - minio
-      - postgres
+      minio:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
     healthcheck:
       test: ["CMD","wget","-qO-","http://localhost:8080/v1/.well-known/ready"]
       interval: 10s
@@ -50,7 +52,8 @@ services:
   weaviate-schema-bootstrap:
     image: python:3.11
     depends_on:
-      - weaviate
+      weaviate:
+        condition: service_healthy
     volumes:
       - ./docker/weaviate:/weaviate:ro
     working_dir: /weaviate

--- a/docker/weaviate/data/.gitignore
+++ b/docker/weaviate/data/.gitignore
@@ -1,0 +1,7 @@
+# Ignore all runtime data
+*
+!postgres/
+!postgres/.gitignore
+!weaviate/
+!weaviate/.gitignore
+!.gitignore

--- a/docker/weaviate/data/postgres/.gitignore
+++ b/docker/weaviate/data/postgres/.gitignore
@@ -1,0 +1,3 @@
+# Ignore all runtime data
+*
+!.gitignore

--- a/docker/weaviate/data/weaviate/.gitignore
+++ b/docker/weaviate/data/weaviate/.gitignore
@@ -1,0 +1,3 @@
+# Ignore all runtime data
+*
+!.gitignore


### PR DESCRIPTION
## Summary
- Start Weaviate only after MinIO and Postgres report healthy, and delay schema bootstrap until Weaviate is ready
- Track writable Weaviate and Postgres data directories with gitignored placeholders
- Allow Weaviate data volumes in the main `.gitignore` for clarity

## Testing
- `docker compose -f docker/compose/docker-compose.weaviate.yaml -f docker/compose/docker-compose.minio.yaml -f docker/compose/docker-compose.postgres.yaml config` *(fails: command not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'video')*

## Checklist
- [x] Code is self-contained and idempotent.
- [x] No unnecessary new files or external dependencies.
- [x] Tests added or updated as appropriate.
- [ ] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_68a4a1f0caf4832682d5b117db8d5caf