### PR TITLE
feat: add compose executor and plan ordering

### DIFF
--- a/host/services/runner/README.md
+++ b/host/services/runner/README.md
@@ -5,13 +5,18 @@ A small agent that fetches plans from the supervisor and applies them determinis
 ## Usage
 
 ```bash
-SUPERVISOR_URL=http://localhost:8070 RUNNER_EXECUTOR=noop go run ./host/services/runner/cmd/runner
+SUPERVISOR_URL=http://localhost:8070 RUNNER_EXECUTOR=docker \
+  go run ./host/services/runner/cmd/runner
 ```
+
+The runner contacts the supervisor for a `DesiredPlan` describing apps to run.
+Apps are started in dependency order using the `after` field.
 
 ## Install (systemd)
 
 ```bash
-SUPERVISOR_URL=http://localhost:8070 RUNNER_EXECUTOR=noop sudo bash scripts/install-runner.sh
+SUPERVISOR_URL=http://localhost:8070 RUNNER_EXECUTOR=docker \
+  sudo bash scripts/install-runner.sh
 ```
 
 ## Tests

--- a/host/services/runner/cmd/runner/order_test.go
+++ b/host/services/runner/cmd/runner/order_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/Cdaprod/ThatDamToolbox/host/services/shared/supervisor/plan"
+)
+
+func TestOrderApps(t *testing.T) {
+	apps := []plan.AppSpec{
+		{Name: "api", After: []string{"db"}},
+		{Name: "web", After: []string{"api"}},
+		{Name: "db"},
+	}
+	ordered, err := orderApps(apps)
+	if err != nil {
+		t.Fatalf("order: %v", err)
+	}
+	got := []string{ordered[0].Name, ordered[1].Name, ordered[2].Name}
+	want := []string{"db", "api", "web"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v want %v", got, want)
+	}
+}
+
+func TestOrderAppsCycle(t *testing.T) {
+	apps := []plan.AppSpec{{Name: "a", After: []string{"b"}}, {Name: "b", After: []string{"a"}}}
+	if _, err := orderApps(apps); err == nil {
+		t.Fatal("expected cycle error")
+	}
+}

--- a/host/services/runner/internal/executor/executor.go
+++ b/host/services/runner/internal/executor/executor.go
@@ -3,13 +3,16 @@ package executor
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"os/exec"
+	"time"
 
-	"github.com/Cdaprod/ThatDamToolbox/host/services/runner/internal/model"
+	"github.com/Cdaprod/ThatDamToolbox/host/services/shared/supervisor/plan"
 )
 
 // Executor applies an App to the local system.
 type Executor interface {
-	Apply(ctx context.Context, app model.App) error
+	Apply(ctx context.Context, dp plan.DesiredPlan) error
 }
 
 // New selects an executor by kind.
@@ -29,29 +32,78 @@ func New(kind string) Executor {
 // DockerCompose uses docker compose.
 type DockerCompose struct{}
 
-func (DockerCompose) Apply(ctx context.Context, app model.App) error {
-	// TODO implement deterministic compose rendering
-	return nil
+func (DockerCompose) Apply(ctx context.Context, dp plan.DesiredPlan) error {
+	return runCompose(ctx, "docker", dp.Apps)
 }
 
 // NerdctlCompose uses nerdctl compose.
 type NerdctlCompose struct{}
 
-func (NerdctlCompose) Apply(ctx context.Context, app model.App) error {
-	return nil
+func (NerdctlCompose) Apply(ctx context.Context, dp plan.DesiredPlan) error {
+	return runCompose(ctx, "nerdctl", dp.Apps)
 }
 
 // SystemdUnits uses systemd units.
 type SystemdUnits struct{}
 
-func (SystemdUnits) Apply(ctx context.Context, app model.App) error {
+func (SystemdUnits) Apply(ctx context.Context, dp plan.DesiredPlan) error {
 	return nil
 }
 
 // Noop prints the intended actions.
 type Noop struct{}
 
-func (Noop) Apply(ctx context.Context, app model.App) error {
-	fmt.Printf("[noop] apply %d services role=%s\n", len(app.Services), app.Role)
+func (Noop) Apply(ctx context.Context, dp plan.DesiredPlan) error {
+	fmt.Printf("[noop] apply %d apps\n", len(dp.Apps))
 	return nil
+}
+
+func runCompose(ctx context.Context, bin string, apps []plan.AppSpec) error {
+	for _, app := range apps {
+		args := append([]string{"compose"}, append(app.Command, app.Name)...)
+		cmd := exec.CommandContext(ctx, bin, args...)
+		cmd.Dir = app.Cwd
+		for k, v := range app.Env {
+			cmd.Env = append(cmd.Env, k+"="+v)
+		}
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("%s %v: %w", bin, args, err)
+		}
+		if app.Health != nil && app.Health.HTTP != "" {
+			if err := waitHealthy(ctx, app.Health.HTTP, app.Health.TimeoutSec, app.Health.IntervalSec); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func waitHealthy(ctx context.Context, url string, timeout, interval int) error {
+	if timeout <= 0 {
+		timeout = 30
+	}
+	if interval <= 0 {
+		interval = 3
+	}
+	deadline := time.Now().Add(time.Duration(timeout) * time.Second)
+	client := &http.Client{Timeout: 3 * time.Second}
+	for {
+		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		resp, err := client.Do(req)
+		if err == nil && resp.StatusCode >= 200 && resp.StatusCode < 400 {
+			resp.Body.Close()
+			return nil
+		}
+		if resp != nil {
+			resp.Body.Close()
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("health timeout: %s", url)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(time.Duration(interval) * time.Second):
+		}
+	}
 }

--- a/host/services/supervisor/README.md
+++ b/host/services/supervisor/README.md
@@ -8,6 +8,13 @@ Control-plane service for agent registration, plans, and environment bootstrappi
 go run ./cmd/supervisor/main.go -addr :8070
 ```
 
+Then start a runner pointing at the supervisor:
+
+```bash
+SUPERVISOR_URL=http://localhost:8070 RUNNER_EXECUTOR=docker \
+  go run ./host/services/runner/cmd/runner
+```
+
 ## Configuration
 
 - `POLICY_ALLOW_ANONYMOUS_PROXY`
@@ -31,7 +38,8 @@ go run ./cmd/supervisor/main.go -addr :8070
   "version": 1,
   "node": "n1",
   "apps": [
-    {"name": "media-api", "kind": "go", "cwd": "/host/services/media-api", "command": ["./media-api"], "env": {"PORT": "8080"}}
+    {"name": "rabbitmq", "kind": "docker", "cwd": "./docker/rabbitmq", "command": ["up", "-d"]},
+    {"name": "api-gateway", "kind": "docker", "cwd": "./host/services/api-gateway", "command": ["up", "-d"], "after": ["rabbitmq"]}
   ]
 }
 ```


### PR DESCRIPTION
## Summary
- add docker/nerdctl compose executor with health checks
- order desired plan apps by `after` dependencies
- document supervisor-runner workflow and add unit tests

## Testing
- `go test ./host/services/runner/... ./host/services/supervisor/...`

## Checklist
- [x] Code is self-contained and idempotent.
- [x] No unnecessary new files or external dependencies.
- [x] Tests added or updated as appropriate.
- [x] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_68a4b83e15648326961368c6838e4b2f