### PR TITLE
Configure Weaviate backups for MinIO

### DIFF
--- a/docker/compose/docker-compose.infra.yaml
+++ b/docker/compose/docker-compose.infra.yaml
@@ -78,10 +78,14 @@ services:
       PERSISTENCE_DATA_PATH:                /var/lib/weaviate
       ENABLE_MODULES:                       backup-s3
       BACKUP_S3_BUCKET:                     weaviate-backups
-      BACKUP_S3_ENDPOINT:                   http://minio:9000
+      BACKUP_S3_ENDPOINT:                   minio:9000
       BACKUP_S3_ACCESS_KEY_ID:              minio
       BACKUP_S3_SECRET_ACCESS_KEY:          minio123
       BACKUP_S3_USE_SSL:                    'false'
+      AWS_S3_FORCE_PATH_STYLE:              'true'
+      AWS_ACCESS_KEY_ID:                    minio
+      AWS_SECRET_ACCESS_KEY:                minio123
+      AWS_REGION:                           us-east-1
       CLUSTER_HOSTNAME:                     node1
       POSTGRES_HOST:                        postgres
       POSTGRES_PASSWORD:                    weaviate

--- a/docker/compose/docker-compose.prod.yaml
+++ b/docker/compose/docker-compose.prod.yaml
@@ -95,10 +95,14 @@ services:
       PERSISTENCE_DATA_PATH:                    /var/lib/weaviate
       ENABLE_MODULES:                           backup-s3
       BACKUP_S3_BUCKET:                         weaviate-backups
-      BACKUP_S3_ENDPOINT:                       http://minio:9000
+      BACKUP_S3_ENDPOINT:                       minio:9000
       BACKUP_S3_ACCESS_KEY_ID:                  minio
       BACKUP_S3_SECRET_ACCESS_KEY:              minio123
       BACKUP_S3_USE_SSL:                        'false'
+      AWS_S3_FORCE_PATH_STYLE:                  'true'
+      AWS_ACCESS_KEY_ID:                        minio
+      AWS_SECRET_ACCESS_KEY:                    minio123
+      AWS_REGION:                               us-east-1
       CLUSTER_HOSTNAME:                         node1
       POSTGRES_HOST:                            postgres
       POSTGRES_PASSWORD:                        weaviate

--- a/docker/compose/docker-compose.weaviate.yaml
+++ b/docker/compose/docker-compose.weaviate.yaml
@@ -18,10 +18,14 @@ services:
       # Enable S3 backup module (targets MinIO)
       ENABLE_MODULES:                            "backup-s3"
       BACKUP_S3_BUCKET:                          "weaviate-backups"
-      BACKUP_S3_ENDPOINT:                        "http://minio:9000"
+      BACKUP_S3_ENDPOINT:                        "minio:9000"
       BACKUP_S3_ACCESS_KEY_ID:                   "thatdam_app"
       BACKUP_S3_SECRET_ACCESS_KEY:               "thatdam_app_secret"
       BACKUP_S3_USE_SSL:                         "false"
+      AWS_S3_FORCE_PATH_STYLE:                   "true"
+      AWS_ACCESS_KEY_ID:                         "thatdam_app"
+      AWS_SECRET_ACCESS_KEY:                     "thatdam_app_secret"
+      AWS_REGION:                                "us-east-1"
 
       # (Optional) Postgres storage
       POSTGRES_HOST:                             "postgres"

--- a/docs/TODO/MINIO-WEAVIATE-PG-POST-BLOBSTORE.md
+++ b/docs/TODO/MINIO-WEAVIATE-PG-POST-BLOBSTORE.md
@@ -135,7 +135,7 @@ services:
       PERSISTENCE_DATA_PATH: /var/lib/weaviate
       ENABLE_MODULES: "backup-s3"
       BACKUP_S3_BUCKET: weaviate-backups
-      BACKUP_S3_ENDPOINT: http://minio:9000
+      BACKUP_S3_ENDPOINT: minio:9000
       BACKUP_S3_ACCESS_KEY_ID: thatdam_app
       BACKUP_S3_SECRET_ACCESS_KEY: thatdam_app_secret
       BACKUP_S3_USE_SSL: "false"


### PR DESCRIPTION
## Summary
- point Weaviate S3 backups at `minio:9000` and enable path-style access
- supply AWS credentials and region for MinIO
- document updated backup endpoint

## Testing
- `pytest` *(fails: Command '['stat', '-f', '-c', '%T', '/data/db']' returned non-zero exit status 1.)*

## Checklist
- [x] Code is self-contained and idempotent.
- [x] No unnecessary new files or external dependencies.
- [ ] Tests added or updated as appropriate.
- [x] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_68a4c3ef98ec8326963d59db190fd461