### PR TITLE
Enable RabbitMQ classic mirrored queue feature flag

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -151,6 +151,7 @@ services:
       RABBITMQ_DEFAULT_PASS: video
       RABBITMQ_DEFAULT_VHOST: /
       RABBITMQ_DISK_FREE_LIMIT: 50MB
+      RABBITMQ_FEATURE_FLAGS: classic_mirrored_queue_version
     ports: ["5672:5672", "15672:15672"]   # 15672 optional (management UI)
     volumes:
       - rabbitmq_data:/var/lib/rabbitmq


### PR DESCRIPTION
## Summary
- enable `classic_mirrored_queue_version` feature flag in RabbitMQ service

## Testing
- `docker compose stop rabbitmq` *(fails: docker: 'compose' is not a docker command)*
- `docker volume rm thatdamtoolbox_rabbitmq_data` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*
- `docker compose up -d rabbitmq` *(fails: unknown shorthand flag: 'd' in -d)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'video')*

## Checklist
- [ ] Code is self-contained and idempotent.
- [ ] No unnecessary new files or external dependencies.
- [ ] Tests added or updated as appropriate.
- [ ] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_68a4c3eccb2c8326a6f6fa2a9fe0c07f