### PR TITLE
feat(platform): add DirEnsurer interface and OS adapter

### DIFF
--- a/host/shared/platform/dir_ensurer.go
+++ b/host/shared/platform/dir_ensurer.go
@@ -1,0 +1,20 @@
+package platform
+
+// DirEnsurer defines an interface for ensuring directories are present
+// with the desired ownership and permissions.
+type DirEnsurer interface {
+	EnsureDirs([]FileSpec) error
+}
+
+// OSDirEnsurer uses the host operating system to ensure directories.
+type OSDirEnsurer struct{}
+
+// EnsureDirs delegates to the package-level EnsureDirs function.
+func (OSDirEnsurer) EnsureDirs(specs []FileSpec) error {
+	return EnsureDirs(specs)
+}
+
+// NewOSDirEnsurer returns a DirEnsurer backed by the host OS implementation.
+func NewOSDirEnsurer() DirEnsurer {
+	return OSDirEnsurer{}
+}

--- a/host/shared/platform/dirs_test.go
+++ b/host/shared/platform/dirs_test.go
@@ -40,3 +40,38 @@ func TestEnsureDirs(t *testing.T) {
 		t.Fatalf("EnsureDirs second call: %v", err)
 	}
 }
+
+func TestOSDirEnsurer(t *testing.T) {
+	t.Parallel()
+	base, err := os.MkdirTemp("", "osdirensurer")
+	if err != nil {
+		t.Fatalf("temp dir: %v", err)
+	}
+	defer os.RemoveAll(base)
+
+	target := filepath.Join(base, "data")
+	uid := os.Getuid()
+	gid := os.Getgid()
+	mode := os.FileMode(0o775)
+	spec := FileSpec{Path: target, UID: uid, GID: gid, Mode: mode}
+
+	ensurer := NewOSDirEnsurer()
+	if err := ensurer.EnsureDirs([]FileSpec{spec}); err != nil {
+		t.Fatalf("EnsureDirs: %v", err)
+	}
+	info, err := os.Stat(target)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Mode().Perm() != mode.Perm() {
+		t.Errorf("mode = %v want %v", info.Mode().Perm(), mode.Perm())
+	}
+	st := info.Sys().(*syscall.Stat_t)
+	if int(st.Uid) != uid || int(st.Gid) != gid {
+		t.Errorf("ownership = %d:%d want %d:%d", st.Uid, st.Gid, uid, gid)
+	}
+	// idempotent via interface
+	if err := ensurer.EnsureDirs([]FileSpec{spec}); err != nil {
+		t.Fatalf("EnsureDirs second call: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add DirEnsurer interface and OSDirEnsurer implementation
- provide constructor `NewOSDirEnsurer`
- test interface implementation

## Checklist
- [x] Code is self-contained and idempotent.
- [x] No unnecessary new files or external dependencies.
- [x] Tests added or updated as appropriate.
- [ ] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_68a4cc8111bc8326ae18d45856d037c1