### PR TITLE
fix: include host shared module in service builds

### DIFF
--- a/host/services/api-gateway/Dockerfile
+++ b/host/services/api-gateway/Dockerfile
@@ -12,6 +12,7 @@ COPY host/services/shared/go.sum        host/services/shared/go.sum
 COPY host/services/shared/hostcap/v4l2probe/go.mod host/services/shared/hostcap/v4l2probe/go.mod
 COPY host/services/api-gateway/go.mod   host/services/api-gateway/go.mod
 COPY host/services/api-gateway/go.sum   host/services/api-gateway/go.sum
+COPY host/shared/go.mod                 host/shared/go.mod
 
 # ── create a minimal workspace (avoid copying repo go.work that includes other modules)
 RUN --mount=type=cache,target=/go/pkg/mod \
@@ -25,6 +26,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 # ── now bring in sources
 COPY host/services/shared/        host/services/shared/
 COPY host/services/api-gateway/   host/services/api-gateway/
+COPY host/shared/                 host/shared/
 
 WORKDIR /src/host/services/api-gateway
 RUN --mount=type=cache,target=/go/pkg/mod \

--- a/host/services/camera-proxy/Dockerfile
+++ b/host/services/camera-proxy/Dockerfile
@@ -12,6 +12,7 @@ COPY host/services/shared/go.sum          host/services/shared/go.sum
 COPY host/services/shared/hostcap/v4l2probe/go.mod host/services/shared/hostcap/v4l2probe/go.mod
 COPY host/services/camera-proxy/go.mod    host/services/camera-proxy/go.mod
 COPY host/services/camera-proxy/go.sum    host/services/camera-proxy/go.sum
+COPY host/shared/go.mod                   host/shared/go.mod
 
 # ── minimal workspace (service + shared)
 RUN --mount=type=cache,target=/go/pkg/mod \
@@ -25,6 +26,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 # ── sources
 COPY host/services/shared/            host/services/shared/
 COPY host/services/camera-proxy/      host/services/camera-proxy/
+COPY host/shared/                     host/shared/
 
 # ── build (main at repo root of module)
 WORKDIR /src/host/services/camera-proxy

--- a/host/services/capture-daemon/Dockerfile
+++ b/host/services/capture-daemon/Dockerfile
@@ -13,6 +13,7 @@ COPY host/services/shared/go.sum            host/services/shared/go.sum
 COPY host/services/shared/hostcap/v4l2probe/go.mod host/services/shared/hostcap/v4l2probe/go.mod
 COPY host/services/capture-daemon/go.mod    host/services/capture-daemon/go.mod
 COPY host/services/capture-daemon/go.sum    host/services/capture-daemon/go.sum
+COPY host/shared/go.mod                     host/shared/go.mod
 
 # 2) Create a minimal workspace (ONLY what we’ll copy: capture-daemon + shared)
 #    Avoid copying repo-root go.work which references missing modules.
@@ -27,6 +28,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 # 3) Copy sources
 COPY host/services/shared/               host/services/shared/
 COPY host/services/capture-daemon/       host/services/capture-daemon/
+COPY host/shared/                        host/shared/
 
 # 4) Build (module root has main.go)
 WORKDIR /src/host/services/capture-daemon

--- a/host/services/discovery/Dockerfile
+++ b/host/services/discovery/Dockerfile
@@ -12,6 +12,7 @@ COPY host/services/shared/go.sum          host/services/shared/go.sum
 COPY host/services/shared/hostcap/v4l2probe/go.mod host/services/shared/hostcap/v4l2probe/go.mod
 COPY host/services/discovery/go.mod       host/services/discovery/go.mod
 COPY host/services/discovery/go.sum       host/services/discovery/go.sum
+COPY host/shared/go.mod                   host/shared/go.mod
 
 # workspace
 RUN --mount=type=cache,target=/go/pkg/mod \
@@ -25,6 +26,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 # sources
 COPY host/services/shared/               host/services/shared/
 COPY host/services/discovery/            host/services/discovery/
+COPY host/shared/                        host/shared/
 
 # build
 WORKDIR /src/host/services/discovery

--- a/host/services/overlay-hub/Dockerfile
+++ b/host/services/overlay-hub/Dockerfile
@@ -12,6 +12,7 @@ COPY host/services/shared/go.sum          host/services/shared/go.sum
 COPY host/services/shared/hostcap/v4l2probe/go.mod host/services/shared/hostcap/v4l2probe/go.mod
 COPY host/services/overlay-hub/go.mod     host/services/overlay-hub/go.mod
 COPY host/services/overlay-hub/go.sum     host/services/overlay-hub/go.sum
+COPY host/shared/go.mod                   host/shared/go.mod
 
 # ── minimal workspace (service + shared)
 RUN --mount=type=cache,target=/go/pkg/mod \
@@ -25,6 +26,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 # ── sources
 COPY host/services/shared/            host/services/shared/
 COPY host/services/overlay-hub/       host/services/overlay-hub/
+COPY host/shared/                     host/shared/
 
 # ── build (expects ./cmd/overlay-hub)
 WORKDIR /src/host/services/overlay-hub

--- a/host/services/supervisor/Dockerfile
+++ b/host/services/supervisor/Dockerfile
@@ -12,6 +12,7 @@ COPY host/services/shared/go.sum          host/services/shared/go.sum
 COPY host/services/shared/hostcap/v4l2probe/go.mod host/services/shared/hostcap/v4l2probe/go.mod
 COPY host/services/supervisor/go.mod      host/services/supervisor/go.mod
 COPY host/services/supervisor/go.sum      host/services/supervisor/go.sum
+COPY host/shared/go.mod                   host/shared/go.mod
 
 # workspace
 RUN --mount=type=cache,target=/go/pkg/mod \
@@ -25,6 +26,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 # sources
 COPY host/services/shared/            host/services/shared/
 COPY host/services/supervisor/        host/services/supervisor/
+COPY host/shared/                     host/shared/
 
 # build (cmd/supervisor is the main package)
 WORKDIR /src/host/services/supervisor


### PR DESCRIPTION
## Summary
- ensure discovery, overlay-hub, supervisor, capture-daemon, camera-proxy, and api-gateway Dockerfiles copy the `host/shared` module

## Testing
- `go test ./...` (discovery) *(fails: DirEnsurer redeclared)*
- `go test ./...` (overlay-hub)
- `go test ./...` (supervisor) *(fails: DirEnsurer redeclared)*
- `go test ./...` (capture-daemon) *(fails: DirEnsurer redeclared)*
- `go test ./...` (camera-proxy)
- `go test ./...` (api-gateway)
- `docker build -f host/services/discovery/Dockerfile .` *(command not found: docker)*

## Checklist
- [x] Code is self-contained and idempotent.
- [x] No unnecessary new files or external dependencies.
- [ ] Tests added or updated as appropriate.
- [x] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_68a4d490bbfc8326bdd30ee497f3ec65