### PR TITLE
Add in-memory claims service with SSE watch

### DIFF
--- a/host/services/supervisor/README.md
+++ b/host/services/supervisor/README.md
@@ -32,6 +32,17 @@ SUPERVISOR_URL=http://localhost:8070 RUNNER_EXECUTOR=docker \
 - `POST /v1/nodes/heartbeat`
 - `GET  /v1/bootstrap/profile`
 - `GET  /v1/leader`
+- `POST /api/claims/new`
+- `GET  /api/claims/{id}/watch`
+- `POST /api/claims/fulfill`
+
+### Claim tokens
+
+`POST /api/claims/new` issues a one-time token and claim ID. Callers may
+watch for fulfilment using Server-Sent Events at
+`/api/claims/{id}/watch`, which emits periodic heartbeats until the
+claim is fulfilled. To complete the flow send the ID and token to
+`/api/claims/fulfill`.
 
 ### DesiredPlan example
 

--- a/host/services/supervisor/cmd/supervisor/main.go
+++ b/host/services/supervisor/cmd/supervisor/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/Cdaprod/ThatDamToolbox/host/services/shared/bus"
 	busamqp "github.com/Cdaprod/ThatDamToolbox/host/services/shared/bus/amqp"
 	"github.com/Cdaprod/ThatDamToolbox/host/services/shared/logx"
+	"github.com/Cdaprod/ThatDamToolbox/host/services/supervisor/internal/claims"
 	envpolicy "github.com/Cdaprod/ThatDamToolbox/host/services/supervisor/internal/policy/envpolicy"
 	"github.com/Cdaprod/ThatDamToolbox/host/services/supervisor/internal/ports"
 	"github.com/MicahParks/keyfunc"
@@ -171,6 +172,11 @@ func main() {
 	mux.HandleFunc("/agents", agentsHandler)
 	mux.HandleFunc("/register", registerHandler)
 	mux.HandleFunc("/heartbeat", heartbeatHandler)
+
+	cs := claims.NewServer(auth)
+	mux.HandleFunc("/api/claims/new", cs.HandleNew)
+	mux.HandleFunc("/api/claims/fulfill", cs.HandleFulfill)
+	mux.HandleFunc("/api/claims/", cs.HandleWatch)
 
 	srv := &http.Server{
 		Addr:              *addr,

--- a/host/services/supervisor/cmd/supervisor/routes_claims_test.go
+++ b/host/services/supervisor/cmd/supervisor/routes_claims_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Cdaprod/ThatDamToolbox/host/services/supervisor/internal/claims"
+)
+
+// TestClaimsLifecycle covers creation, watching, and fulfilment.
+func TestClaimsLifecycle(t *testing.T) {
+	cs := claims.NewServer(auth)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/claims/new", nil)
+	cs.HandleNew(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("new status %d", rr.Code)
+	}
+	var resp map[string]string
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	id, tok := resp["id"], resp["token"]
+	if id == "" || tok == "" {
+		t.Fatal("missing id or token")
+	}
+
+	watchRec := httptest.NewRecorder()
+	watchReq := httptest.NewRequest(http.MethodGet, "/api/claims/"+id+"/watch", nil)
+	done := make(chan struct{})
+	go func() {
+		cs.HandleWatch(watchRec, watchReq)
+		close(done)
+	}()
+
+	fulfilReqBody := fmt.Sprintf(`{"id":"%s","token":"%s"}`, id, tok)
+	fulfRec := httptest.NewRecorder()
+	fulfReq := httptest.NewRequest(http.MethodPost, "/api/claims/fulfill", strings.NewReader(fulfilReqBody))
+	cs.HandleFulfill(fulfRec, fulfReq)
+	if fulfRec.Code != http.StatusNoContent {
+		t.Fatalf("fulfill status %d", fulfRec.Code)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("watch timeout")
+	}
+	if !strings.Contains(watchRec.Body.String(), "fulfilled") {
+		t.Fatalf("watch body %q", watchRec.Body.String())
+	}
+}

--- a/host/services/supervisor/internal/claims/http.go
+++ b/host/services/supervisor/internal/claims/http.go
@@ -1,0 +1,127 @@
+package claims
+
+// HTTP handlers for the claim store.
+//
+// Example curl to create and fulfil a claim:
+//
+//  curl -X POST http://localhost:8070/api/claims/new
+//  curl -X POST http://localhost:8070/api/claims/fulfill -d '{"id":"<id>","token":"<token>"}'
+//
+// Watchers may listen for fulfilment via Server-Sent Events:
+//
+//  curl http://localhost:8070/api/claims/<id>/watch
+//
+// All handlers expect authentication via the existing auth(r) helper.
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/Cdaprod/ThatDamToolbox/host/services/supervisor/internal/ports"
+)
+
+// AuthFunc matches the auth function from cmd/supervisor.
+type AuthFunc func(*http.Request) (ports.Principal, error)
+
+// Server bundles handlers with a Store and auth hook.
+type Server struct {
+	store *Store
+	auth  AuthFunc
+}
+
+// NewServer constructs a claims server with the provided auth func.
+func NewServer(auth AuthFunc) *Server {
+	return &Server{store: NewStore(), auth: auth}
+}
+
+// HandleNew issues a new claim token.
+// Example: curl -X POST http://localhost:8070/api/claims/new
+func (s *Server) HandleNew(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if _, err := s.auth(r); err != nil {
+		http.Error(w, err.Error(), http.StatusUnauthorized)
+		return
+	}
+	id, token := s.store.New()
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]string{"id": id, "token": token})
+}
+
+// HandleWatch streams fulfilment updates via SSE.
+// Example: curl http://localhost:8070/api/claims/<id>/watch
+func (s *Server) HandleWatch(w http.ResponseWriter, r *http.Request) {
+	if _, err := s.auth(r); err != nil {
+		http.Error(w, err.Error(), http.StatusUnauthorized)
+		return
+	}
+	parts := strings.Split(strings.TrimPrefix(r.URL.Path, "/api/claims/"), "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] != "watch" {
+		http.NotFound(w, r)
+		return
+	}
+	id := parts[0]
+	ch, ok := s.store.Watch(id)
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "stream unsupported", http.StatusInternalServerError)
+		return
+	}
+	ticker := time.NewTicker(15 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ch:
+			w.Write([]byte("data: fulfilled\n\n"))
+			flusher.Flush()
+			return
+		case <-ticker.C:
+			w.Write([]byte(": heartbeat\n\n"))
+			flusher.Flush()
+		case <-r.Context().Done():
+			return
+		}
+	}
+}
+
+// HandleFulfill marks a claim fulfilled given an ID and token.
+// Example: curl -X POST http://localhost:8070/api/claims/fulfill -d '{"id":"<id>","token":"<token>"}'
+func (s *Server) HandleFulfill(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if _, err := s.auth(r); err != nil {
+		http.Error(w, err.Error(), http.StatusUnauthorized)
+		return
+	}
+	var req struct {
+		ID    string `json:"id"`
+		Token string `json:"token"`
+	}
+	dec := json.NewDecoder(r.Body)
+	if err := dec.Decode(&req); err != nil || req.ID == "" || req.Token == "" {
+		http.Error(w, "bad json", http.StatusBadRequest)
+		return
+	}
+	if ok := s.store.Fulfill(req.ID, req.Token); !ok {
+		http.Error(w, "invalid claim", http.StatusNotFound)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// ErrUnauthorized is returned when auth fails.
+var ErrUnauthorized = errors.New("unauthorized")

--- a/host/services/supervisor/internal/claims/model.go
+++ b/host/services/supervisor/internal/claims/model.go
@@ -1,0 +1,87 @@
+package claims
+
+// Package claims implements a lightweight in-memory token claim store.
+//
+// The store is intentionally ephemeral and suitable for tests. It
+// generates opaque claim IDs and tokens and exposes methods to watch
+// and fulfil claims.
+//
+// Example:
+//
+//  cs := claims.NewStore()
+//  id, token := cs.New()
+//  go func() { <-cs.Watch(id); fmt.Println("fulfilled") }()
+//  cs.Fulfill(id, token)
+//
+// All operations are safe for concurrent use.
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"sync"
+)
+
+// Claim represents an issuance awaiting fulfilment.
+type Claim struct {
+	ID        string
+	Token     string
+	Fulfilled bool
+	ch        chan struct{}
+}
+
+// Store keeps claims in memory.
+type Store struct {
+	mu     sync.RWMutex
+	claims map[string]*Claim
+}
+
+// NewStore constructs an empty store.
+func NewStore() *Store {
+	return &Store{claims: make(map[string]*Claim)}
+}
+
+// New creates a fresh claim and returns its ID and token.
+func (s *Store) New() (string, string) {
+	id := randHex(16)
+	token := randHex(16)
+	c := &Claim{ID: id, Token: token, ch: make(chan struct{})}
+	s.mu.Lock()
+	s.claims[id] = c
+	s.mu.Unlock()
+	return id, token
+}
+
+// Fulfill marks the claim done if the token matches.
+func (s *Store) Fulfill(id, token string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	c, ok := s.claims[id]
+	if !ok || c.Token != token || c.Fulfilled {
+		return false
+	}
+	c.Fulfilled = true
+	close(c.ch)
+	return true
+}
+
+// Watch returns a channel closed once the claim is fulfilled.
+func (s *Store) Watch(id string) (<-chan struct{}, bool) {
+	s.mu.RLock()
+	c, ok := s.claims[id]
+	s.mu.RUnlock()
+	if !ok {
+		return nil, false
+	}
+	if c.Fulfilled {
+		ch := make(chan struct{})
+		close(ch)
+		return ch, true
+	}
+	return c.ch, true
+}
+
+func randHex(n int) string {
+	b := make([]byte, n)
+	_, _ = rand.Read(b)
+	return hex.EncodeToString(b)
+}


### PR DESCRIPTION
## Summary
- add in-memory claim token store with handlers for new, watch, and fulfill flows
- wire claims endpoints into supervisor
- document claims API and implement basic lifecycle test

## Testing
- `go test ./host/services/supervisor/...` *(fails: DirEnsurer redeclared in host/shared/platform and build failures in storage_fs and reconcile)*

## Checklist
- [x] Code is self-contained and idempotent.
- [x] No unnecessary new files or external dependencies.
- [x] Tests added or updated as appropriate.
- [x] Docs updated where needed.

------
https://chatgpt.com/codex/tasks/task_e_68a4d9d7abb48326aa2efe54ffeff423