### PR TITLE
feat(web-app): add device provisioning modal

### DIFF
--- a/docker/web-app/README.md
+++ b/docker/web-app/README.md
@@ -277,3 +277,9 @@ Recording is controlled via simple HTTP calls:
 curl -X POST http://<host>/daemon/record/start
 curl -X POST http://<host>/daemon/record/stop
 ```
+
+## Provisioning a Device
+
+1. Navigate to **Dashboard → Camera Monitor**.
+2. Click **Provision Device**.
+3. Copy the displayed join command and run it on the target device. The modal watches `/api/claims/{id}/watch` and updates once the device connects.

--- a/docker/web-app/src/components/CameraMonitor/index.tsx
+++ b/docker/web-app/src/components/CameraMonitor/index.tsx
@@ -679,6 +679,12 @@ const CameraMonitor: React.FC = () => {
             >
               ▶ PLAY
             </button>
+            <button
+              onClick={() => openModal("provision-device")}
+              className="w-full p-2 mb-1 bg-gradient-to-br from-gray-600 to-gray-700 border border-gray-500 rounded text-white text-xs cursor-pointer transition-all duration-200 hover:from-gray-500 hover:to-gray-600 hover:-translate-y-0.5"
+            >
+              Provision Device
+            </button>
           </div>
 
           {/* Monitoring Tools */}

--- a/docker/web-app/src/components/modals/ProvisionDeviceModal.tsx
+++ b/docker/web-app/src/components/modals/ProvisionDeviceModal.tsx
@@ -1,0 +1,103 @@
+// /docker/web-app/src/components/modals/ProvisionDeviceModal.tsx
+'use client';
+import { Dialog, Transition } from '@headlessui/react';
+import { Fragment, useEffect, useState } from 'react';
+
+interface Claim {
+  id: string;
+  command: string;
+}
+
+interface Props {
+  open: boolean;
+  onClose(): void;
+}
+
+// Fetches a new claim from the API
+// Example: await createClaim()
+export async function createClaim(): Promise<Claim> {
+  const res = await fetch('/api/claims/new');
+  if (!res.ok) throw new Error('failed to create claim');
+  return res.json();
+}
+
+export default function ProvisionDeviceModal({ open, onClose }: Props) {
+  const [claim, setClaim] = useState<Claim | null>(null);
+  const [done, setDone] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    let es: EventSource | null = null;
+
+    createClaim()
+      .then((c) => {
+        setClaim(c);
+        es = new EventSource(`/api/claims/${c.id}/watch`);
+        es.onmessage = () => {
+          setDone(true);
+          es?.close();
+        };
+      })
+      .catch((e) => setError(e.message));
+
+    return () => {
+      es?.close();
+    };
+  }, [open]);
+
+  return (
+    <Transition.Root show={open} as={Fragment}>
+      <Dialog as="div" className="relative z-50" onClose={onClose}>
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-200"
+          enterFrom="opacity-0 backdrop-blur-0"
+          enterTo="opacity-100 backdrop-blur-sm"
+          leave="ease-in duration-150"
+          leaveFrom="opacity-100 backdrop-blur-sm"
+          leaveTo="opacity-0 backdrop-blur-0"
+        >
+          <div className="fixed inset-0 bg-black/40" />
+        </Transition.Child>
+
+        <div className="fixed inset-0 flex items-center justify-center p-4">
+          <Transition.Child
+            as={Fragment}
+            enter="ease-out duration-200"
+            enterFrom="opacity-0 scale-95"
+            enterTo="opacity-100 scale-100"
+            leave="ease-in duration-150"
+            leaveFrom="opacity-100 scale-100"
+            leaveTo="opacity-0 scale-95"
+          >
+            <Dialog.Panel className="w-full max-w-lg rounded-xl bg-white shadow-xl overflow-hidden flex flex-col">
+              <header className="flex justify-between items-center p-4 border-b">
+                <h3 className="text-lg font-semibold">Provision Device</h3>
+                <button
+                  onClick={onClose}
+                  className="text-sm font-medium text-gray-500 hover:text-gray-700"
+                >
+                  ✕
+                </button>
+              </header>
+              <div className="p-4 space-y-4">
+                {error && <p className="text-red-600">{error}</p>}
+                {!error && !claim && <p>Generating join command...</p>}
+                {claim && (
+                  <div>
+                    <p className="mb-2 text-sm">Run this on the device:</p>
+                    <code className="block bg-gray-100 p-2 rounded text-sm break-all">
+                      {claim.command}
+                    </code>
+                  </div>
+                )}
+                {done && <p className="text-green-600">Device provisioned.</p>}
+              </div>
+            </Dialog.Panel>
+          </Transition.Child>
+        </div>
+      </Dialog>
+    </Transition.Root>
+  );
+}

--- a/docker/web-app/src/components/modals/__tests__/ProvisionDeviceModal.test.tsx
+++ b/docker/web-app/src/components/modals/__tests__/ProvisionDeviceModal.test.tsx
@@ -1,0 +1,18 @@
+import test from 'node:test'
+import assert from 'node:assert'
+import { createClaim } from '../ProvisionDeviceModal'
+
+test('createClaim requests new claim and returns join command', async () => {
+  const called: string[] = []
+  const originalFetch = globalThis.fetch
+  globalThis.fetch = (async (url: string) => {
+    called.push(url)
+    return { ok: true, json: async () => ({ id: '1', command: 'join me' }) } as any
+  }) as any
+
+  const claim = await createClaim()
+  assert.deepEqual(claim, { id: '1', command: 'join me' })
+  assert.equal(called[0], '/api/claims/new')
+
+  globalThis.fetch = originalFetch!
+})

--- a/docker/web-app/src/providers/ModalProvider.tsx
+++ b/docker/web-app/src/providers/ModalProvider.tsx
@@ -4,6 +4,7 @@ import { createContext, useContext, useState, ReactNode, Fragment } from 'react'
 import { Dialog, Transition } from '@headlessui/react';
 import CameraMonitorModal from '@/components/modals/CameraMonitorModal';
 import DAMExplorerModal   from '@/components/modals/DAMExplorerModal';
+import ProvisionDeviceModal from '@/components/modals/ProvisionDeviceModal';
 
 type ToolKey =
   | 'camera-monitor'
@@ -12,6 +13,7 @@ type ToolKey =
   | 'motion'
   | 'live'
   | 'witness'
+  | 'provision-device'
   | null;
 
 interface ModalCtx {
@@ -33,6 +35,8 @@ export default function ModalProvider({ children }: { children: ReactNode }) {
         return <CameraMonitorModal open onClose={closeModal} />;
       case 'dam-explorer':
         return <DAMExplorerModal open onClose={closeModal} />;
+      case 'provision-device':
+        return <ProvisionDeviceModal open onClose={closeModal} />;
       /* add other compact modals here */
       default:
         return null;

--- a/docker/web-app/tsconfig.test.json
+++ b/docker/web-app/tsconfig.test.json
@@ -9,6 +9,7 @@
   },
   "include": [
     "src/components/__tests__/**/*.tsx",
+    "src/components/modals/__tests__/**/*.tsx",
     "src/hooks/__tests__/**/*.tsx",
     "src/providers/__tests__/**/*.tsx",
     "src/lib/__tests__/**/*.ts",


### PR DESCRIPTION
## Summary
- add ProvisionDeviceModal to fetch join command and watch claim
- wire modal into provider and camera monitor
- document device provisioning workflow

## Testing
- `npm test` *(fails: Could not find '/workspace/ThatDAMToolbox/docker/web-app/.tmp-test/**/*.test.js')*
- `rm -rf .tmp-test && tsc -p tsconfig.test.json && node --test $(find .tmp-test -name '*.test.js')`

## Checklist
- [x] Code is self-contained and idempotent.
- [x] No unnecessary new files or external dependencies.
- [x] Tests added or updated as appropriate.
- [x] Docs updated where needed.

------
https://chatgpt.com/codex/tasks/task_e_68a4d9fceb6c8326a7d398b5d16d1fcc