### PR TITLE
Remove stray dam-explorer tag from dashboard template

### DIFF
--- a/video/tests/test_dashboard_template.py
+++ b/video/tests/test_dashboard_template.py
@@ -1,0 +1,20 @@
+"""Tests for the dashboard template's Explorer mount point.
+
+Example:
+    pytest video/tests/test_dashboard_template.py
+"""
+from pathlib import Path
+from jinja2 import Environment, FileSystemLoader
+
+
+def test_dashboard_has_single_mount_point():
+    """`dashboard.html` renders exactly one React Explorer mount point."""
+    templates_dir = Path(__file__).resolve().parents[1] / "web" / "templates"
+    env = Environment(loader=FileSystemLoader(templates_dir))
+
+    html = env.get_template("dashboard.html").render(
+        url_for=lambda name, path: f"/{path}"
+    )
+
+    assert html.count('id="dam-root"') == 1
+    assert "<dam-explorer" not in html

--- a/video/web/templates/dashboard.html
+++ b/video/web/templates/dashboard.html
@@ -146,9 +146,6 @@
 {% block body %}
   <div id="content">
     <h1>🎬 Davids Video Processing Dashboard 🎬</h1>
-    <!-- 🔥 Make this the main interactive dashboard area: -->
-    <dam-explorer></dam-explorer>
-    <!-- Optionally, add fallback content here for noscript/browser without JS -->
     <div class="dashboard-grid">
 
       <div class="primary-row">


### PR DESCRIPTION
## Summary
- drop unused `<dam-explorer>` element so only Explorer card provides mount point
- add test asserting dashboard renders a single DAM Explorer mount

## Testing
- `pytest video/tests/test_dashboard_template.py -q`

## Checklist
- [x] Code is self-contained and idempotent.
- [x] No unnecessary new files or external dependencies.
- [x] Tests added or updated as appropriate.
- [ ] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_68a4e423879083268a16833823720367