### PR TITLE
fix: ensure rabbitmq volume directory exists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,6 +159,7 @@ host/releases/
 !/docker/web-app/tsconfig.test.json
 !/docker/rabbitmq/definitions.json
 docker/rabbitmq/data/
+!docker/rabbitmq/data/.gitkeep
 !/docker/weaviate/schema.json
 !/docker/proxy-viewer/package.json
 !/docker/proxy-viewer/tsconfig.json

--- a/docker/rabbitmq/data/.gitkeep
+++ b/docker/rabbitmq/data/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to keep directory for RabbitMQ volume


### PR DESCRIPTION
Milestone: 🧬 Feature Development
Scope: docker
Linked Issues: N/A

## Summary
- ensure RabbitMQ data volume directory exists for docker-compose
- allow tracking placeholder via gitignore exception

## Testing
- `pytest -q` *(fails: KeyboardInterrupt during weaviate import)*


------
https://chatgpt.com/codex/tasks/task_e_68a5279c53cc832694b82d9c5d63915a