### PR TITLE
feat(bus): add file-backed log adapter

### DIFF
--- a/host/services/shared/AGENTS.md
+++ b/host/services/shared/AGENTS.md
@@ -7,3 +7,5 @@ Scope: Common Go packages and middleware reused by host services.
 - Each subpackage needs focused unit tests and clear docs.
 - Avoid global state; expose explicit constructors and interfaces.
 - Update this file and README when adding new packages.
+- `bus/log` implements an append-only, file-backed bus adapter for
+  Kafka-like sequential I/O.

--- a/host/services/shared/README.md
+++ b/host/services/shared/README.md
@@ -20,3 +20,15 @@ The `catalog` package exposes `Asset` metadata and the `Catalog` interface.
 var c catalog.Catalog // provided by supervisor
 assets, _ := c.ListByFolder("recordings", 1, 10)
 ```
+
+## Bus
+
+The `bus` package offers a minimal publish/subscribe API with pluggable
+adapters. In addition to the default AMQP adapter, `bus/log` provides a
+file-backed, append-only log for Kafka-like sequential I/O patterns.
+
+```go
+log.Register()
+b, _ := bus.Connect(context.Background(), bus.Config{URL: "/tmp/bus", Exchange: "events"})
+_ = b.Publish("topic", []byte("msg"))
+```

--- a/host/services/shared/bus/log/log.go
+++ b/host/services/shared/bus/log/log.go
@@ -1,0 +1,105 @@
+package log
+
+// Package log provides a simple append-only message bus that writes
+// messages to topic-based log files. It mimics Kafka's sequential disk
+// access pattern but is scoped for local development and testing.
+//
+// Usage:
+//
+//import (
+//"context"
+//"github.com/Cdaprod/ThatDamToolbox/host/services/shared/bus"
+//"github.com/Cdaprod/ThatDamToolbox/host/services/shared/bus/log"
+//)
+//
+//func main() {
+//log.Register()
+//b, _ := bus.Connect(context.Background(), bus.Config{URL: "/tmp/bus", Exchange: ""})
+//_ = b.Publish("foo", []byte("hello"))
+//}
+//
+// The adapter stores messages under <dir>/<topic>.log and delivers them
+// to subscribers in publish order.
+//
+// Example:
+//
+//// go test ./host/services/shared/bus/log
+//
+import (
+	"bufio"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/Cdaprod/ThatDamToolbox/host/services/shared/bus"
+)
+
+// Adapter implements bus.Bus using append-only log files.
+type Adapter struct {
+	dir  string
+	mu   sync.RWMutex
+	subs map[string][]func([]byte)
+}
+
+// New creates a new log-backed bus. cfg.URL should point to a directory
+// where topic log files will be created.
+func New(cfg bus.Config) (bus.Bus, error) {
+	if cfg.URL == "" {
+		return nil, errors.New("log: missing directory")
+	}
+	if err := os.MkdirAll(cfg.URL, 0o755); err != nil {
+		return nil, err
+	}
+	return &Adapter{dir: cfg.URL, subs: make(map[string][]func([]byte))}, nil
+}
+
+// Publish appends b to the topic log and notifies subscribers.
+func (a *Adapter) Publish(topic string, b []byte) error {
+	path := filepath.Join(a.dir, topic+".log")
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return err
+	}
+	if _, err := f.Write(append(b, '\n')); err != nil {
+		f.Close()
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		f.Close()
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+
+	a.mu.RLock()
+	subs := append([]func([]byte){}, a.subs[topic]...)
+	a.mu.RUnlock()
+	for _, fn := range subs {
+		fn(b)
+	}
+	return nil
+}
+
+// Subscribe replays existing messages for topic and registers fn for future ones.
+func (a *Adapter) Subscribe(topic string, fn func([]byte)) error {
+	path := filepath.Join(a.dir, topic+".log")
+	if f, err := os.Open(path); err == nil {
+		scanner := bufio.NewScanner(f)
+		for scanner.Scan() {
+			fn([]byte(scanner.Text()))
+		}
+		_ = f.Close()
+	}
+	a.mu.Lock()
+	a.subs[topic] = append(a.subs[topic], fn)
+	a.mu.Unlock()
+	return nil
+}
+
+// Close releases resources. The log adapter holds no long-lived resources.
+func (a *Adapter) Close() error { return nil }
+
+// Register sets the log adapter as the bus default.
+func Register() { bus.SetAdapter(New) }

--- a/host/services/shared/bus/log/log_test.go
+++ b/host/services/shared/bus/log/log_test.go
@@ -1,0 +1,54 @@
+package log
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/Cdaprod/ThatDamToolbox/host/services/shared/bus"
+)
+
+// TestPublishSubscribe ensures messages are appended and delivered in order.
+func TestPublishSubscribe(t *testing.T) {
+	dir := t.TempDir()
+	Register()
+	cfg := bus.Config{URL: dir, Exchange: "events"}
+	if _, err := bus.Connect(context.Background(), cfg); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+
+	var mu sync.Mutex
+	var got [][]byte
+	if err := bus.Subscribe("foo", func(b []byte) {
+		mu.Lock()
+		defer mu.Unlock()
+		got = append(got, append([]byte(nil), b...))
+	}); err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+
+	if err := bus.Publish("foo", "a"); err != nil {
+		t.Fatalf("publish a: %v", err)
+	}
+	if err := bus.Publish("foo", "b"); err != nil {
+		t.Fatalf("publish b: %v", err)
+	}
+
+	mu.Lock()
+	if len(got) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(got))
+	}
+	mu.Unlock()
+
+	data, err := os.ReadFile(filepath.Join(dir, "foo.log"))
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d", len(lines))
+	}
+}


### PR DESCRIPTION
Milestone: 🧬 Feature Development
Scope: host/services/shared/bus
Linked Issues: N/A

## Summary
- add append-only file-backed bus adapter for Kafka-style sequential I/O
- document new bus/log adapter and update shared package guide

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68a51c68aa7083269c830071cef5293c