### PR TITLE
feat: inspect docker container state

### DIFF
--- a/host/services/shared/README.md
+++ b/host/services/shared/README.md
@@ -20,3 +20,9 @@ The `catalog` package exposes `Asset` metadata and the `Catalog` interface.
 var c catalog.Catalog // provided by supervisor
 assets, _ := c.ListByFolder("recordings", 1, 10)
 ```
+
+## Bootstrap
+
+The `bootstrap` module provides lightweight service runtime adapters. The
+`runtime_docker` adapter now uses `docker inspect` to populate `UnitState` with
+the container's running status, PID, and exit code.

--- a/host/services/shared/bootstrap/adapters/runtime_docker/docker.go
+++ b/host/services/shared/bootstrap/adapters/runtime_docker/docker.go
@@ -2,7 +2,9 @@ package runtimedocker
 
 import (
 	"context"
+	"encoding/json"
 	"os/exec"
+	"strings"
 
 	ports "github.com/Cdaprod/ThatDamToolbox/host/services/shared/bootstrap/ports"
 )
@@ -39,7 +41,35 @@ func (d DockerRuntime) Stop(ctx context.Context, name string) error {
 	return nil
 }
 
-// State always reports the unit as inactive. Detailed inspection is TODO.
+// State inspects the container and reports its status.
+//
+// Example:
+//
+//	st, _ := rt.State(ctx, "busy")
+//	fmt.Println(st.Active)
+//
+// The function uses `docker inspect` to determine whether the container is
+// running and captures the PID, exit code, and status message.
 func (d DockerRuntime) State(ctx context.Context, name string) (ports.UnitState, error) {
-	return ports.UnitState{Name: name, Active: false}, nil
+	cmd := exec.CommandContext(ctx, d.Bin, "inspect", name, "--format", "{{json .State}}")
+	out, err := cmd.Output()
+	if err != nil {
+		return ports.UnitState{Name: name, Active: false, Message: strings.TrimSpace(err.Error())}, nil
+	}
+	var s struct {
+		Running  bool   `json:"Running"`
+		Pid      int    `json:"Pid"`
+		ExitCode int    `json:"ExitCode"`
+		Status   string `json:"Status"`
+	}
+	if err := json.Unmarshal(out, &s); err != nil {
+		return ports.UnitState{Name: name, Active: false, Message: err.Error()}, err
+	}
+	return ports.UnitState{
+		Name:     name,
+		Active:   s.Running,
+		Pid:      s.Pid,
+		ExitCode: s.ExitCode,
+		Message:  s.Status,
+	}, nil
 }

--- a/host/services/shared/bootstrap/adapters/runtime_docker/docker_test.go
+++ b/host/services/shared/bootstrap/adapters/runtime_docker/docker_test.go
@@ -1,0 +1,52 @@
+package runtimedocker
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestStateRunning verifies that State reports an active container.
+func TestStateRunning(t *testing.T) {
+	tmp := t.TempDir()
+	stub := filepath.Join(tmp, "docker")
+	script := "#!/bin/sh\nif [ \"$2\" = \"running\" ]; then\n  echo '{\"Running\":true,\"Pid\":111,\"ExitCode\":0,\"Status\":\"running\"}'\nelse\n  echo '{\"Running\":false,\"Pid\":0,\"ExitCode\":42,\"Status\":\"exited\"}'\nfi\n"
+	if err := os.WriteFile(stub, []byte(script), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	origPath := os.Getenv("PATH")
+	os.Setenv("PATH", tmp+":"+origPath)
+	defer os.Setenv("PATH", origPath)
+
+	rt := New("")
+	st, err := rt.State(context.Background(), "running")
+	if err != nil {
+		t.Fatalf("state: %v", err)
+	}
+	if !st.Active || st.Pid != 111 || st.ExitCode != 0 || st.Message != "running" {
+		t.Fatalf("unexpected state: %+v", st)
+	}
+}
+
+// TestStateStopped verifies that State reports an exited container.
+func TestStateStopped(t *testing.T) {
+	tmp := t.TempDir()
+	stub := filepath.Join(tmp, "docker")
+	script := "#!/bin/sh\nif [ \"$2\" = \"running\" ]; then\n  echo '{\"Running\":true,\"Pid\":111,\"ExitCode\":0,\"Status\":\"running\"}'\nelse\n  echo '{\"Running\":false,\"Pid\":0,\"ExitCode\":7,\"Status\":\"exited\"}'\nfi\n"
+	if err := os.WriteFile(stub, []byte(script), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	origPath := os.Getenv("PATH")
+	os.Setenv("PATH", tmp+":"+origPath)
+	defer os.Setenv("PATH", origPath)
+
+	rt := New("")
+	st, err := rt.State(context.Background(), "stopped")
+	if err != nil {
+		t.Fatalf("state: %v", err)
+	}
+	if st.Active || st.ExitCode != 7 || st.Message != "exited" {
+		t.Fatalf("unexpected state: %+v", st)
+	}
+}

--- a/host/services/shared/bootstrap/adapters/runtime_exec/exec.go
+++ b/host/services/shared/bootstrap/adapters/runtime_exec/exec.go
@@ -80,7 +80,7 @@ func (rt *ExecRuntime) State(ctx context.Context, name string) (ports.UnitState,
 	rt.mu.Lock()
 	_, ok := rt.procs[name]
 	rt.mu.Unlock()
-	return ports.UnitState{Name: name, Active: ok}, nil
+	return ports.UnitState{Name: name, Active: ok, ExitCode: 0}, nil
 }
 
 func formatEnv(m map[string]string) []string {

--- a/host/services/shared/bootstrap/adapters/runtime_ns/ns.go
+++ b/host/services/shared/bootstrap/adapters/runtime_ns/ns.go
@@ -22,5 +22,5 @@ func (NSRuntime) Stop(ctx context.Context, name string) error { return nil }
 
 // State reports the unit as inactive.
 func (NSRuntime) State(ctx context.Context, name string) (ports.UnitState, error) {
-	return ports.UnitState{Name: name, Active: false}, nil
+	return ports.UnitState{Name: name, Active: false, ExitCode: 0}, nil
 }

--- a/host/services/shared/bootstrap/ports/runtime.go
+++ b/host/services/shared/bootstrap/ports/runtime.go
@@ -19,10 +19,11 @@ type UnitSpec struct {
 
 // UnitState reports the status of a service unit.
 type UnitState struct {
-	Name    string
-	Active  bool
-	Pid     int
-	Message string
+	Name     string
+	Active   bool
+	Pid      int
+	ExitCode int
+	Message  string
 }
 
 // ServiceRuntime abstracts how node services are managed.


### PR DESCRIPTION
Milestone: 🧬 Feature Development
Scope: host/services/shared
Linked Issues: 

## Summary
- use `docker inspect` to determine container PID, exit code, and status
- expose exit code on `UnitState` and update runtime adapters
- document bootstrap runtime behavior and add docker runtime tests

## Testing
- `go test ./...`

## Checklist
- [x] Code is self-contained and idempotent.
- [x] No unnecessary new files or external dependencies.
- [x] Tests added or updated as appropriate.
- [x] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_68a5cc79b8108326a85f7914a3bbd2db