### PR TITLE
fix(minio): use curl for healthcheck

### DIFF
--- a/docker/minio/Dockerfile
+++ b/docker/minio/Dockerfile
@@ -28,5 +28,10 @@ COPY --from=mcget /mc /usr/bin/mc
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
+# Install curl for healthchecks and scripting
+RUN apt-get update \
+    && apt-get install -y curl \
+    && rm -rf /var/lib/apt/lists/*
+
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["server","/data","--console-address",":9001"]

--- a/docker/minio/entrypoint.sh
+++ b/docker/minio/entrypoint.sh
@@ -24,7 +24,7 @@ MINIO_BUCKET_WEAVIATE_BACKUPS="${MINIO_BUCKET_WEAVIATE_BACKUPS:-}"
 MINIO_PID=$!
 
 for i in $(seq 1 60); do
-  if wget -qO- http://127.0.0.1:9000/minio/health/ready >/dev/null 2>&1; then
+  if curl -fSs http://127.0.0.1:9000/minio/health/ready >/dev/null 2>&1; then
     READY=1
     break
   fi

--- a/tests/test_minio_entrypoint.py
+++ b/tests/test_minio_entrypoint.py
@@ -5,6 +5,8 @@ def test_entrypoint_basic():
     assert 'minio server /data --console-address :9001' in content
     assert 'mc alias set' in content
     assert 'mc mb' in content
+    assert 'curl -fSs' in content
+    assert 'wget' not in content
     assert 'su ' not in content
     assert 'chown' not in content
 


### PR DESCRIPTION
Milestone: 🧬 Feature Development
Scope: docker/minio
Linked Issues: N/A

## Summary
- install curl in custom MinIO image
- swap entrypoint readiness probe to use curl
- test MinIO entrypoint for curl usage

## Testing
- `PYTHONPATH=. pytest tests/test_minio_entrypoint.py -q` *(fails: Module import error: llvmlite/whisper dependencies)*
- `docker compose -f docker/compose/docker-compose.minio.yaml build minio` *(fails: unknown shorthand flag: 'f')*
- `docker-compose -f docker/compose/docker-compose.minio.yaml build minio` *(fails: Error while fetching server API version: connection aborted)*
- `dockerd` *(fails: failed to start daemon: permission denied on iptables/overlay)*

## Checklist
- [x] Code is self-contained and idempotent.
- [x] No unnecessary new files or external dependencies.
- [x] Tests added or updated as appropriate.
- [ ] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_68a5cc654c7c8326a1d83e2f78589f2c