### PR TITLE
feat: support public and CORS settings for MinIO media bucket

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,9 +199,10 @@ This document explains the key principles and details you’ll need to develop a
 ---
 
 ## Ports & Adapters (optional services are pluggable)
-- ObjectStorage (FS default; MinIO optional)  
-- EventBus (in-proc default; RabbitMQ optional)  
-- VectorIndex (in-mem default; Weaviate optional)  
+- ObjectStorage (FS default; MinIO optional)
+  - MinIO entrypoint supports `MINIO_MEDIA_PUBLIC=true` for public media buckets and `MINIO_MEDIA_CORS_JSON` for custom CORS.
+- EventBus (in-proc default; RabbitMQ optional)
+- VectorIndex (in-mem default; Weaviate optional)
 Discovery selects adapters from env; reconcilers are idempotent and non-destructive.
 
 ---

--- a/docker/minio/entrypoint.sh
+++ b/docker/minio/entrypoint.sh
@@ -10,6 +10,8 @@
 #     -e MINIO_ROOT_USER=minio \
 #     -e MINIO_ROOT_PASSWORD=minio123 \
 #     -e MINIO_BUCKET_MEDIA=media \
+#     -e MINIO_MEDIA_PUBLIC=true \
+#     -e MINIO_MEDIA_CORS_JSON='[{"AllowedMethods":["GET"],"AllowedOrigins":["*"]}]' \
 #     thatdamtoolbox-minio
 
 set -euo pipefail
@@ -19,6 +21,8 @@ set -euo pipefail
 
 MINIO_BUCKET_MEDIA="${MINIO_BUCKET_MEDIA:-}"
 MINIO_BUCKET_WEAVIATE_BACKUPS="${MINIO_BUCKET_WEAVIATE_BACKUPS:-}"
+MINIO_MEDIA_PUBLIC="${MINIO_MEDIA_PUBLIC:-false}"
+MINIO_MEDIA_CORS_JSON="${MINIO_MEDIA_CORS_JSON:-}"
 
 /usr/bin/minio server /data --console-address :9001 >/proc/1/fd/1 2>/proc/1/fd/2 &
 MINIO_PID=$!
@@ -51,5 +55,16 @@ ensure_bucket() {
 
 ensure_bucket "$MINIO_BUCKET_MEDIA"
 ensure_bucket "$MINIO_BUCKET_WEAVIATE_BACKUPS"
+
+if [[ "$MINIO_MEDIA_PUBLIC" == "true" && -n "$MINIO_BUCKET_MEDIA" ]]; then
+  mc anonymous set download "local/${MINIO_BUCKET_MEDIA}" >/dev/null
+fi
+
+if [[ -n "$MINIO_MEDIA_CORS_JSON" && -n "$MINIO_BUCKET_MEDIA" ]]; then
+  cors_tmp=$(mktemp)
+  printf '%s' "$MINIO_MEDIA_CORS_JSON" > "$cors_tmp"
+  mc cors set "local/${MINIO_BUCKET_MEDIA}" "$cors_tmp" >/dev/null
+  rm -f "$cors_tmp"
+fi
 
 wait "$MINIO_PID"

--- a/script_tests/test_minio_entrypoint.py
+++ b/script_tests/test_minio_entrypoint.py
@@ -1,0 +1,60 @@
+"""Tests for docker/minio/entrypoint.sh behavior.
+
+Example:
+    pytest script_tests/test_minio_entrypoint.py -q
+"""
+
+import os
+import pathlib
+import shutil
+import subprocess
+
+SCRIPT = pathlib.Path(__file__).resolve().parents[1] / "docker" / "minio" / "entrypoint.sh"
+
+
+def test_sets_public_and_cors(tmp_path):
+    log = tmp_path / "log"
+
+    mc = tmp_path / "mc"
+    mc.write_text(
+        "#!/usr/bin/env bash\n"
+        f"echo mc \"$@\" >> \"{log}\"\n"
+        f"if [ \"$1\" = \"cors\" ] && [ \"$2\" = \"set\" ]; then\n"
+        f"  echo cors_json \"$(cat \"$4\")\" >> \"{log}\"\n"
+        "fi\n"
+        "if [ \"$1\" = \"ls\" ]; then exit 1; fi\n"
+    )
+    mc.chmod(0o755)
+
+    wget = tmp_path / "wget"
+    wget.write_text("#!/usr/bin/env bash\nexit 0\n")
+    wget.chmod(0o755)
+
+    minio = tmp_path / "minio"
+    minio.write_text("#!/usr/bin/env bash\nsleep 0.1\n")
+    minio.chmod(0o755)
+    sys_minio = pathlib.Path("/usr/bin/minio")
+    shutil.copy2(minio, sys_minio)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{tmp_path}:{env['PATH']}"
+    env.update(
+        {
+            "MINIO_ROOT_USER": "minio",
+            "MINIO_ROOT_PASSWORD": "minio123",
+            "MINIO_BUCKET_MEDIA": "media",
+            "MINIO_MEDIA_PUBLIC": "true",
+            "MINIO_MEDIA_CORS_JSON": '{"AllowedMethods":["GET"],"AllowedOrigins":["*"]}',
+        }
+    )
+
+    try:
+        result = subprocess.run(["bash", str(SCRIPT)], env=env, text=True, capture_output=True)
+    finally:
+        sys_minio.unlink(missing_ok=True)
+
+    assert result.returncode == 0
+    lines = log.read_text().splitlines()
+    assert f"mc anonymous set download local/{env['MINIO_BUCKET_MEDIA']}" in lines
+    assert f"cors_json {env['MINIO_MEDIA_CORS_JSON']}" in lines
+


### PR DESCRIPTION
Milestone: 🧬 Feature Development
Scope: docker/minio
Linked Issues: N/A

## Summary
- allow MINIO_MEDIA_PUBLIC to grant anonymous read on media bucket
- apply JSON from MINIO_MEDIA_CORS_JSON via mc cors set
- document options in AGENTS guide and add script test

## Testing
- `pytest script_tests/test_minio_entrypoint.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'video')*
- `docker build -t tdt-minio-test docker/minio` *(fails: Cannot connect to the Docker daemon)*

## Checklist
- [ ] Code is self-contained and idempotent.
- [ ] No unnecessary new files or external dependencies.
- [ ] Tests added or updated as appropriate.
- [ ] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_68a5ccb555848326b377412f9fc81181