### PR TITLE
feat: open dam explorer modal from top bar

### DIFF
--- a/docker/web-app/src/components/TopBar.tsx
+++ b/docker/web-app/src/components/TopBar.tsx
@@ -4,9 +4,11 @@
 import clsx from 'clsx'
 import { Menu, X } from 'lucide-react'
 import { useSidebar } from '../hooks/useSidebar'
+import { useModal } from '@/providers/ModalProvider'
 
 export default function TopBar() {
   const { collapsed, setCollapsed } = useSidebar()
+  const { openModal } = useModal()
 
   return (
     <header
@@ -31,9 +33,13 @@ export default function TopBar() {
 
       {/* right – placeholder for future buttons */}
       <nav className="flex items-center gap-4">
-        <a href="/dashboard/dam-explorer" className="text-body hover:text-theme-primary">
+        <button
+          type="button"
+          onClick={() => openModal('dam-explorer')}
+          className="text-body hover:text-theme-primary"
+        >
           Explorer
-        </a>
+        </button>
       </nav>
     </header>
   );

--- a/docker/web-app/src/components/__tests__/TopBar.test.tsx
+++ b/docker/web-app/src/components/__tests__/TopBar.test.tsx
@@ -2,6 +2,7 @@ import assert from 'node:assert'
 import test from 'node:test'
 import React from 'react'
 import { renderToString } from 'react-dom/server'
+import path from 'node:path'
 
 import TopBar from '../TopBar'
 import Sidebar from '../Sidebar'
@@ -28,4 +29,33 @@ test('Sidebar shows titles when expanded', () => {
 
 test('MainLayout shows sidebar on camera monitor route', () => {
   assert.equal(shouldHideSidebar('/dashboard/camera-monitor'), false)
+})
+
+test('Explorer button triggers dam-explorer modal', async () => {
+  const sidebarPath = path.resolve(__dirname, '../../hooks/useSidebar.js')
+  const modalPath = path.resolve(__dirname, '../../providers/ModalProvider.js')
+  const topBarPath = path.resolve(__dirname, '../TopBar.js')
+
+  const sidebarMod = require(sidebarPath)
+  const modalMod = require(modalPath)
+  const origUseSidebar = sidebarMod.useSidebar
+  const origUseModal = modalMod.useModal
+
+  let opened: string | null = null
+
+  sidebarMod.useSidebar = () => ({ collapsed: false, setCollapsed() {} })
+  modalMod.useModal = () => ({ openModal: (tool: string) => { opened = tool }, closeModal() {} })
+
+  delete require.cache[topBarPath]
+  const { default: TestTopBar } = await import('../TopBar')
+  const el = TestTopBar()
+  const nav = el.props.children[1]
+  const button = nav.props.children
+  button.props.onClick()
+
+  assert.equal(opened, 'dam-explorer')
+
+  sidebarMod.useSidebar = origUseSidebar
+  modalMod.useModal = origUseModal
+  delete require.cache[topBarPath]
 })


### PR DESCRIPTION
Milestone: 🧬 Feature Development
Scope: docker/web-app
Linked Issues: N/A

## Summary
- open dam explorer modal via new top bar button
- test modal context integration on explorer button

## Testing
- `npm test` *(fails: TS errors in CameraMonitor and overlays)*

## Checklist
- [ ] Code is self-contained and idempotent.
- [ ] No unnecessary new files or external dependencies.
- [ ] Tests added or updated as appropriate.
- [ ] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_68a5f76ab8c88326beafd282105cad1e