### PR TITLE
feat(web-app): replace hex colors with tokens

### DIFF
--- a/docker/web-app/src/styles/__tests__/theme.test.ts
+++ b/docker/web-app/src/styles/__tests__/theme.test.ts
@@ -1,0 +1,23 @@
+import test from 'node:test'
+import assert from 'node:assert'
+import { deviceOptionStyle, sliderBackgroundStyle, statusClasses } from '../theme'
+
+test('deviceOptionStyle uses CSS variable tokens', () => {
+  const unavailable = deviceOptionStyle(false)
+  assert.match((unavailable.color ?? '') as string, /var\(--color-/)
+  assert.match((unavailable.background ?? '') as string, /var\(--color-/)
+})
+
+test('sliderBackgroundStyle references slider tokens', () => {
+  const style = sliderBackgroundStyle(50)
+  const bg = style.background as string
+  assert.ok(bg.includes('var(--color-slider-fill)'))
+  assert.ok(bg.includes('var(--color-slider-track)'))
+})
+
+test('statusClasses use semantic tokens', () => {
+  Object.values(statusClasses).forEach(cls => {
+    assert.match(cls, /var\(--color-[a-z-]+\)/)
+    assert.ok(!/#/.test(cls))
+  })
+})

--- a/docker/web-app/src/styles/theme.ts
+++ b/docker/web-app/src/styles/theme.ts
@@ -34,10 +34,10 @@ export const overlaySurfaceStyle: CSSProperties = {
 };
 
 export const monitorCanvasStyle: CSSProperties = {
-  background: 'black',
+  background: 'var(--color-monitor-canvas)',
 };
 
-export const videoCardStyle:    CSSProperties = { margin: 8, border: '1px solid #333', padding: 12 };
+export const videoCardStyle:    CSSProperties = { margin: 8, border: '1px solid var(--color-border)', padding: 12 };
 export const videoStyle:        CSSProperties = { display: 'block', marginBottom: 8, maxWidth: '100%' };
 export const videoInfoStyle:    CSSProperties = { fontSize: 14, marginBottom: 4 };
 export const sceneThumbStyle:   CSSProperties = { marginRight: 2 };
@@ -64,12 +64,12 @@ export const folderIndentStyle = (level: number): CSSProperties => ({
 });
 
 export const deviceOptionStyle = (available: boolean): CSSProperties => ({
-  color:      available ? '#fff' : '#888',
-  background: available ? ''     : '#333',
+  color:      available ? 'var(--color-surface)' : 'var(--color-muted)',
+  background: available ? ''                    : 'var(--color-text)',
 });
 
 export const sliderBackgroundStyle = (percent: number): CSSProperties => ({
-  background: `linear-gradient(to right, #ff4500 0%, #ff4500 ${percent}%, #666 ${percent}%, #666 100%)`,
+  background: `linear-gradient(to right, var(--color-slider-fill) 0%, var(--color-slider-fill) ${percent}%, var(--color-slider-track) ${percent}%, var(--color-slider-track) 100%)`,
 });
 
 export const batteryLevelStyle = (level: number): CSSProperties => ({
@@ -77,18 +77,18 @@ export const batteryLevelStyle = (level: number): CSSProperties => ({
 });
 
 export const statusClasses: Record<'success' | 'error' | 'warning' | 'info', string> = {
-  success: 'bg-green-100 text-green-800 border-green-300',
-  error:   'bg-red-100   text-red-800   border-red-300',
-  warning: 'bg-yellow-100 text-yellow-800 border-yellow-300',
-  info:    'bg-blue-100  text-blue-800  border-blue-300',
+  success: 'bg-[var(--color-success-bg)] text-[var(--color-success-text)] border-[var(--color-success-border)]',
+  error:   'bg-[var(--color-error-bg)]   text-[var(--color-error-text)]   border-[var(--color-error-border)]',
+  warning: 'bg-[var(--color-warning-bg)] text-[var(--color-warning-text)] border-[var(--color-warning-border)]',
+  info:    'bg-[var(--color-info-bg)]    text-[var(--color-info-text)]    border-[var(--color-info-border)]',
 };
 
 export const dashboardColorClasses: Record<string, string> = {
-  'camera-monitor': 'text-indigo-500',
-  'dam-explorer':   'text-purple-500',
-  motion:           'text-pink-500',
-  live:             'text-green-500',
-  witness:          'text-yellow-500',
-  explorer:         'text-blue-500',
-  nodes:            'text-cyan-500',
+  'camera-monitor': 'text-[var(--color-camera-monitor)]',
+  'dam-explorer':   'text-[var(--color-accent)]',
+  motion:           'text-[var(--color-motion)]',
+  live:             'text-[var(--color-live)]',
+  witness:          'text-[var(--color-witness)]',
+  explorer:         'text-[var(--color-primary)]',
+  nodes:            'text-[var(--color-nodes)]',
 };

--- a/docker/web-app/src/styles/tokens.css
+++ b/docker/web-app/src/styles/tokens.css
@@ -29,6 +29,33 @@
   --color-accent:     #a855f7; /* purple-500 */
   --color-accent-bg:  #f5f3ff; /* purple-50 */
 
+  /* Status colors */
+  --color-success-bg:  #dcfce7; /* green-100 */
+  --color-success-border: #86efac; /* green-300 */
+  --color-success-text:   #166534; /* green-800 */
+
+  --color-error-bg:   #fee2e2; /* red-100 */
+  --color-error-border: #fca5a5; /* red-300 */
+  --color-error-text:  #991b1b; /* red-800 */
+
+  --color-warning-bg:  #fef9c3; /* yellow-100 */
+  --color-warning-border: #fde68a; /* yellow-300 */
+  --color-warning-text:   #92400e; /* yellow-800 */
+
+  --color-info-bg:     #dbeafe; /* blue-100 */
+  --color-info-border: #93c5fd; /* blue-300 */
+  --color-info-text:   #1e40af; /* blue-800 */
+
+  /* Component-specific */
+  --color-slider-fill:   #ff4500;
+  --color-slider-track:  #666666;
+  --color-monitor-canvas: #000000;
+  --color-camera-monitor: #6366f1; /* indigo-500 */
+  --color-motion:         #ec4899; /* pink-500 */
+  --color-live:           #22c55e; /* green-500 */
+  --color-witness:        #eab308; /* yellow-500 */
+  --color-nodes:          #06b6d4; /* cyan-500 */
+
   /* Typography */
   --font-body: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
   --font-weight-regular: 400;

--- a/docker/web-app/tsconfig.test.json
+++ b/docker/web-app/tsconfig.test.json
@@ -13,6 +13,7 @@
     "src/hooks/__tests__/**/*.tsx",
     "src/providers/__tests__/**/*.tsx",
     "src/lib/__tests__/**/*.ts",
+    "src/styles/__tests__/**/*.ts",
     "src/components/tools/FFmpegConsole.tsx",
     "src/components/tools/AnalyticsCard.tsx",
     "src/components/tools/MotionExtract.tsx",


### PR DESCRIPTION
Milestone: 🧬 Feature Development
Scope: web-app
Linked Issues: n/a

## Summary
- replace hard-coded colors in theme helpers with CSS variable tokens
- expose semantic status styles via var(--color-*) references
- add tests ensuring theme uses design tokens

## Testing
- `npx -y tsc -p docker/web-app/tsconfig.test.json`
- `node --test $(find docker/web-app/.tmp-test -name '*.test.js')`
- `npm --prefix docker/web-app run lint` *(fails: prompts for ESLint config)*

## Checklist
- [x] Code is self-contained and idempotent.
- [x] No unnecessary new files or external dependencies.
- [x] Tests added or updated as appropriate.
- [ ] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_68a5ff57095c8326a9e0245cee8a84c7