### PR TITLE
fix: define local anchors in compose includes

### DIFF
--- a/docker/compose/docker-compose.video-api.yaml
+++ b/docker/compose/docker-compose.video-api.yaml
@@ -1,3 +1,25 @@
+# local anchors live in THIS file (anchors don't cross includes)
+x-logging: &default-logging
+  driver: json-file
+  options:
+    max-size: "10m"
+    max-file: "5"
+
+x-build-common: &build-common
+  args:
+    BUILDKIT_INLINE_CACHE: "1"
+  cache_from:
+    - type=local,src=.docker_cache
+  cache_to:
+    - type=local,dest=.docker_cache,mode=max
+  labels:
+    org.opencontainers.image.source: "https://github.com/Cdaprod/Media-Indexer-Stdlib-Prototype"
+    org.opencontainers.image.vendor: "Cdaprod"
+    org.opencontainers.image.title: "ThatDAMToolbox"
+    org.opencontainers.image.revision: "${GIT_SHA:-dev}"
+    org.opencontainers.image.version: "${IMAGE_TAG:-dev}"
+    org.opencontainers.image.licenses: "Apache-2.0"
+
 services:
   ########################################################################
   # 4a. FastAPI back-end (mapped => reachable on host :8080)

--- a/docker/compose/docker-compose.video-web.yaml
+++ b/docker/compose/docker-compose.video-web.yaml
@@ -1,3 +1,25 @@
+# local anchors live in THIS file (anchors don't cross includes)
+x-logging: &default-logging
+  driver: json-file
+  options:
+    max-size: "10m"
+    max-file: "5"
+
+x-build-common: &build-common
+  args:
+    BUILDKIT_INLINE_CACHE: "1"
+  cache_from:
+    - type=local,src=.docker_cache
+  cache_to:
+    - type=local,dest=.docker_cache,mode=max
+  labels:
+    org.opencontainers.image.source: "https://github.com/Cdaprod/Media-Indexer-Stdlib-Prototype"
+    org.opencontainers.image.vendor: "Cdaprod"
+    org.opencontainers.image.title: "ThatDAMToolbox"
+    org.opencontainers.image.revision: "${GIT_SHA:-dev}"
+    org.opencontainers.image.version: "${IMAGE_TAG:-dev}"
+    org.opencontainers.image.licenses: "Apache-2.0"
+
 services:
   video-web:
     build:

--- a/docker/compose/docker-compose.web-site.yaml
+++ b/docker/compose/docker-compose.web-site.yaml
@@ -1,3 +1,25 @@
+# local anchors live in THIS file (anchors don't cross includes)
+x-logging: &default-logging
+  driver: json-file
+  options:
+    max-size: "10m"
+    max-file: "5"
+
+x-build-common: &build-common
+  args:
+    BUILDKIT_INLINE_CACHE: "1"
+  cache_from:
+    - type=local,src=.docker_cache
+  cache_to:
+    - type=local,dest=.docker_cache,mode=max
+  labels:
+    org.opencontainers.image.source: "https://github.com/Cdaprod/Media-Indexer-Stdlib-Prototype"
+    org.opencontainers.image.vendor: "Cdaprod"
+    org.opencontainers.image.title: "ThatDAMToolbox"
+    org.opencontainers.image.revision: "${GIT_SHA:-dev}"
+    org.opencontainers.image.version: "${IMAGE_TAG:-dev}"
+    org.opencontainers.image.licenses: "Apache-2.0"
+
 services:
   web-site:
     build:


### PR DESCRIPTION
Milestone: 🧬 Feature Development
Scope: docker
Linked Issues: N/A

## Summary
- define per-file logging and build anchors in video-api compose
- add local anchors to video-web compose
- add local anchors to web-site compose

## Testing
- `python - <<'PY'\nimport yaml, sys, pathlib\nfiles = ['docker/compose/docker-compose.video-api.yaml','docker/compose/docker-compose.video-web.yaml','docker/compose/docker-compose.web-site.yaml']\nfor f in files:\n    try:\n        with open(f) as fh:\n            yaml.safe_load(fh)\n        print(f"OK: {f}")\n    except Exception as e:\n        print(f"FAIL: {f}: {e}")\nPY`

## Checklist
- [ ] Code is self-contained and idempotent.
- [ ] No unnecessary new files or external dependencies.
- [ ] Tests added or updated as appropriate.
- [ ] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_68a61a096cc8832696562db62b114a77