### PR TITLE
feat(web-app): unify theme and soften styling

### DIFF
--- a/docker/web-app/src/context/ThemeContext.tsx
+++ b/docker/web-app/src/context/ThemeContext.tsx
@@ -1,57 +1,23 @@
 // /src/context/ThemeContext.tsx
 import { ReactNode, useEffect } from 'react'
-import { usePathname } from 'next/navigation'
 
-// Map of route -> CSS variable overrides
-const THEME_MAP: Record<string, Record<string, string>> = {
-  'camera-monitor': {
-    '--theme-background': '#eef2ff',
-    '--theme-primary':    '#6366f1',
-    '--theme-accent':     '#c7d2fe',
-  },
-  'dam-explorer': {
-    '--theme-background': '#f5f3ff',
-    '--theme-primary':    '#8b5cf6',
-    '--theme-accent':     '#ddd6fe',
-  },
-  motion: {
-    '--theme-background': '#fdf2f8',
-    '--theme-primary':    '#ec4899',
-    '--theme-accent':     '#f9a8d4',
-  },
-  live: {
-    '--theme-background': '#f0fdf4',
-    '--theme-primary':    '#22c55e',
-    '--theme-accent':     '#86efac',
-  },
-  witness: {
-    '--theme-background': '#fffbeb',
-    '--theme-primary':    '#eab308',
-    '--theme-accent':     '#fef08a',
-  },
-  explorer: {
-    '--theme-background': '#eff6ff',
-    '--theme-primary':    '#3b82f6',
-    '--theme-accent':     '#bfdbfe',
-  },
+// Single theme applied across the app to avoid a route-based rainbow
+const THEME_VARS: Record<string, string> = {
+  '--theme-background': '#f0f4ff',
+  '--theme-primary':    '#1e40af',
+  '--theme-accent':     '#3b82f6',
 }
 
-export function deriveThemeId(pathname: string) {
-  const segments = pathname.split('/').filter(Boolean)
-  const last = segments.pop()
-  return last && THEME_MAP[last] ? last : 'camera-monitor'
+export function deriveThemeId(_: string) {
+  return 'default'
 }
 
 export function ThemeProvider({ children }: { children: ReactNode }) {
-  const pathname = usePathname()
-
   useEffect(() => {
-    const id = deriveThemeId(pathname)
-    const themeVars = THEME_MAP[id] ?? THEME_MAP['camera-monitor']
-    Object.entries(themeVars).forEach(([k, v]) =>
+    Object.entries(THEME_VARS).forEach(([k, v]) =>
       document.documentElement.style.setProperty(k, v)
     )
-  }, [pathname])
+  }, [])
 
   return <>{children}</>
 }

--- a/docker/web-app/src/context/__tests__/ThemeContext.test.tsx
+++ b/docker/web-app/src/context/__tests__/ThemeContext.test.tsx
@@ -2,10 +2,7 @@ import test from 'node:test'
 import assert from 'node:assert'
 import { deriveThemeId } from '../ThemeContext'
 
-test('handles tenant-prefixed paths', () => {
-  assert.strictEqual(deriveThemeId('/tenant/dam-explorer'), 'dam-explorer')
-})
-
-test('falls back to camera-monitor when unknown', () => {
-  assert.strictEqual(deriveThemeId('/tenant/unknown'), 'camera-monitor')
+test('deriveThemeId returns default for any path', () => {
+  assert.strictEqual(deriveThemeId('/tenant/dam-explorer'), 'default')
+  assert.strictEqual(deriveThemeId('/tenant/unknown'), 'default')
 })

--- a/docker/web-app/src/styles/README.md
+++ b/docker/web-app/src/styles/README.md
@@ -50,6 +50,16 @@ Adjusting these variables updates layout across the app without touching markup.
 
 Utilities are defined in `globals.css` under the `@layer utilities` block.
 
+### Theme Variables
+
+A default blue theme applies across the app via three CSS variables:
+
+- `--theme-background`
+- `--theme-primary`
+- `--theme-accent`
+
+Changing these values updates the global background and accent colors without touching component markup.
+
 ## Color Tokens
 
 Color tokens allow components to stay theme-aware without hardcoding Tailwind palette values.

--- a/docker/web-app/src/styles/__tests__/theme.test.ts
+++ b/docker/web-app/src/styles/__tests__/theme.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test'
 import assert from 'node:assert'
-import { deviceOptionStyle, sliderBackgroundStyle, statusClasses } from '../theme'
+import { cardBaseClasses, deviceOptionStyle, sliderBackgroundStyle, statusClasses } from '../theme'
 
 test('deviceOptionStyle uses CSS variable tokens', () => {
   const unavailable = deviceOptionStyle(false)
@@ -20,4 +20,9 @@ test('statusClasses use semantic tokens', () => {
     assert.match(cls, /var\(--color-[a-z-]+\)/)
     assert.ok(!/#/.test(cls))
   })
+})
+
+test('cardBaseClasses include rounding and shadow', () => {
+  assert.match(cardBaseClasses, /rounded-xl/)
+  assert.match(cardBaseClasses, /shadow-md/)
 })

--- a/docker/web-app/src/styles/theme.ts
+++ b/docker/web-app/src/styles/theme.ts
@@ -5,7 +5,7 @@ export const gridStyle: CSSProperties = {
   gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
 };
 
-export const cardBaseClasses = 'bg-surface rounded-lg shadow-sm border border-color-border';
+export const cardBaseClasses = 'bg-surface rounded-xl shadow-md border border-color-border';
 
 export const sizeClasses: Record<'small' | 'medium' | 'large', string> = {
   small:  'p-2 sm:p-4 min-h-[100px] sm:min-h-[120px]',

--- a/docker/web-app/src/styles/tokens.css
+++ b/docker/web-app/src/styles/tokens.css
@@ -115,6 +115,11 @@
   --color-text-on-warning: #111827;
   --color-text-on-error  : #ffffff;
 
+  /* Theme colors */
+  --theme-background: #f0f4ff;
+  --theme-primary:    #1e40af;
+  --theme-accent:     #3b82f6;
+
   /* Status colors */
   --color-success-bg:  #dcfce7; /* green-100 */
   --color-success-border: #86efac; /* green-300 */
@@ -150,9 +155,9 @@
   --text-heading: 1.25rem;  /* 20 */
 
   /* Radii */
-  --radius-sm: 4px;
-  --radius-md: 6px;
-  --radius-lg: 8px;
+  --radius-sm: 6px;
+  --radius-md: 10px;
+  --radius-lg: 14px;
 
   /* Shadows */
   --shadow-sm: 0 1px 2px rgba(0,0,0,0.05);


### PR DESCRIPTION
Milestone: 🧬 Feature Development
Scope: web-app
Linked Issues: 

## Summary
- consolidate theme to a single blue palette and apply globally
- soften card appearance with larger radius and shadow
- document new theme variables for easy customization

## Testing
- `rm -rf .tmp-test && tsc -p tsconfig.test.json && node --test $(find .tmp-test -name '*.test.js')`
- `npm run lint` *(prompts for ESLint setup)*

## Checklist
- [x] Code is self-contained and idempotent.
- [x] No unnecessary new files or external dependencies.
- [x] Tests added or updated as appropriate.
- [x] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_68a61ea6d7e88326a653d4287f080033