### PR TITLE
feat(web-app): expose assets API via /api route

### DIFF
--- a/docker/web-app/next.config.js
+++ b/docker/web-app/next.config.js
@@ -1,11 +1,12 @@
 // /webapp/next.config.js
 // /docker/web-app/next.config.js
-const path = require('path');
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://host.docker.internal:8080';
+const path = require("path");
+const API_BASE =
+  process.env.NEXT_PUBLIC_API_BASE_URL || "http://host.docker.internal:8080";
 
 module.exports = {
   reactStrictMode: true,
-  output: 'standalone',
+  output: "standalone",
 
   async rewrites() {
     // anything under /api/video/* → your video-api
@@ -13,44 +14,47 @@ module.exports = {
     // DAM Explorer → your FastAPI explorer endpoints
     return [
       {
-        source: '/api/video/:path*',
+        source: "/api/video/:path*",
         destination: `${API_BASE}/api/video/:path*`,
       },
       {
-        source: '/live/:path*',
+        source: "/live/:path*",
         destination: `${API_BASE}/hwcapture/live/:path*`,
       },
       {
-        source: '/assets',
+        source: "/api/assets",
         destination: `${API_BASE}/explorer/assets`,
       },
       {
-        source: '/folders',
+        source: "/folders",
         destination: `${API_BASE}/explorer/folders`,
       },
-    ]
+    ];
   },
 
   async headers() {
     return [
       {
-        source: '/_next/static/:path*',
-        headers: [
-          { key: 'Cache-Control', value: 'public, max-age=31536000, immutable' },
-        ],
-      },
-      {
-        source: '/assets/thumbs/:path*',
-        headers: [
-          { key: 'Cache-Control', value: 'public, max-age=2592000, immutable' },
-        ],
-      },
-      {
-        source: '/api/:path*',
+        source: "/_next/static/:path*",
         headers: [
           {
-            key: 'Cache-Control',
-            value: 'public, max-age=5, s-maxage=60, stale-while-revalidate=120',
+            key: "Cache-Control",
+            value: "public, max-age=31536000, immutable",
+          },
+        ],
+      },
+      {
+        source: "/assets/thumbs/:path*",
+        headers: [
+          { key: "Cache-Control", value: "public, max-age=2592000, immutable" },
+        ],
+      },
+      {
+        source: "/api/:path*",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "public, max-age=5, s-maxage=60, stale-while-revalidate=120",
           },
         ],
       },
@@ -58,35 +62,35 @@ module.exports = {
   },
 
   images: {
-    domains: ['localhost'],
-    unoptimized: process.env.NODE_ENV === 'development',
+    domains: ["localhost"],
+    unoptimized: process.env.NODE_ENV === "development",
   },
 
   webpack: (config, { dev, isServer }) => {
     // 1) teach webpack that '@' roots at your /src dir
     config.resolve.alias = {
       ...(config.resolve.alias || {}),
-      '@'         : path.resolve(__dirname, 'src'),
-      '@components': path.resolve(__dirname, 'src/components'),
-      '@app'      : path.resolve(__dirname, 'src/app'),
-      '@lib'      : path.resolve(__dirname, 'src/lib'),
-      '@styles'   : path.resolve(__dirname, 'src/styles'),
-      '@providers': path.resolve(__dirname, 'src/providers'),
-    }
+      "@": path.resolve(__dirname, "src"),
+      "@components": path.resolve(__dirname, "src/components"),
+      "@app": path.resolve(__dirname, "src/app"),
+      "@lib": path.resolve(__dirname, "src/lib"),
+      "@styles": path.resolve(__dirname, "src/styles"),
+      "@providers": path.resolve(__dirname, "src/providers"),
+    };
 
     // 2) for polling in dev
     if (dev && !isServer) {
       config.watchOptions = {
         poll: 1000,
         aggregateTimeout: 300,
-      }
+      };
     }
 
-    return config
+    return config;
   },
 
   env: {
     // you already have these set in .env.local
     // NEXT_PUBLIC_API_BASE_URL, NEXT_PUBLIC_WS_URL
   },
-}
+};

--- a/docker/web-app/src/app/assets/__tests__/page.test.tsx
+++ b/docker/web-app/src/app/assets/__tests__/page.test.tsx
@@ -1,0 +1,23 @@
+/**
+ * AssetsPage integration: renders list when API returns data.
+ * Run with: npm test
+ */
+import assert from "node:assert";
+import test from "node:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import AssetsPage from "../page";
+
+(global as any).fetch = async (input: any) => {
+  const url = input.toString();
+  assert.equal(url, "/api/assets?limit=100");
+  return {
+    ok: true,
+    json: async () => ({ items: [{ id: "1", name: "Asset 1" }] }),
+  } as any;
+};
+
+test("AssetsPage renders asset list", async () => {
+  const html = renderToStaticMarkup(await AssetsPage());
+  assert.ok(html.includes("<li"));
+  assert.ok(html.includes("Asset 1"));
+});

--- a/docker/web-app/src/app/assets/page.tsx
+++ b/docker/web-app/src/app/assets/page.tsx
@@ -5,18 +5,21 @@
 export const revalidate = 60;
 
 export default async function AssetsPage() {
-  const res = await fetch(
-    `${process.env.NEXT_PUBLIC_API_BASE_URL}/explorer/assets?limit=100`,
-  );
-  if (!res.ok) {
-    throw new Error('Failed to fetch assets');
+  try {
+    const res = await fetch("/api/assets?limit=100");
+    if (!res.ok) {
+      throw new Error("Failed to fetch assets");
+    }
+    const data = await res.json();
+    return (
+      <ul>
+        {data.items?.map((item: any) => (
+          <li key={item.id}>{item.name ?? item.id}</li>
+        ))}
+      </ul>
+    );
+  } catch (err) {
+    console.error("Error loading assets", err);
+    return <p>Unable to load assets.</p>;
   }
-  const data = await res.json();
-  return (
-    <ul>
-      {data.items?.map((item: any) => (
-        <li key={item.id}>{item.name ?? item.id}</li>
-      ))}
-    </ul>
-  );
 }

--- a/docker/web-app/tsconfig.test.json
+++ b/docker/web-app/tsconfig.test.json
@@ -16,6 +16,7 @@
     "src/styles/__tests__/**/*.ts",
     "src/context/__tests__/**/*.tsx",
     "src/app/*/dashboard/__tests__/**/*.tsx",
+    "src/app/assets/__tests__/**/*.tsx",
     "src/types/**/*.d.ts",
     "src/components/tools/FFmpegConsole.tsx",
     "src/components/tools/AnalyticsCard.tsx",


### PR DESCRIPTION
Milestone: 🧬 Feature Development
Scope: web-app
Linked Issues: N/A

## Summary
- route assets API through /api/assets to avoid conflicting with page
- fetch assets via /api/assets with basic error handling
- test assets page renders list from API

## Testing
- `rm -rf .tmp-test && tsc -p tsconfig.test.json && node --test $(find .tmp-test -name '*.test.js')`
- `pytest tests/test_dam_explorer_asset.py -q` *(fails: ModuleNotFoundError: No module named 'video')*


------
https://chatgpt.com/codex/tasks/task_e_68a65e6aeedc8326adc14c6f9a997236