### PR TITLE
feat: add witness device selection and tests

### DIFF
--- a/docker/web-app/src/app/[tenant]/dashboard/witness/page.tsx
+++ b/docker/web-app/src/app/[tenant]/dashboard/witness/page.tsx
@@ -1,8 +1,84 @@
+"use client";
+
+import { useDevices, useStartWitness } from "@/lib/videoQueries";
+import { useEffect, useState } from "react";
+
 export default function WitnessToolPage() {
   return (
     <section className="p-8">
       <h2 className="text-3xl font-bold mb-4">Witness Tool</h2>
-      <p>Review witness camera footage and events.</p>
+      <WitnessRecorder />
     </section>
+  );
+}
+
+function WitnessRecorder() {
+  const { data: devices } = useDevices();
+  const startWitness = useStartWitness();
+  const [main, setMain] = useState("");
+  const [wit, setWit] = useState("");
+
+  useEffect(() => {
+    if (devices?.length) {
+      setMain((m) => m || devices[0].path);
+      setWit((w) => w || devices[Math.min(1, devices.length - 1)].path);
+    }
+  }, [devices]);
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <select
+            className="w-full mb-2"
+            value={main}
+            onChange={(e) => setMain(e.target.value)}
+          >
+            {devices?.map((d) => (
+              <option key={d.path} value={d.path}>
+                {d.path}
+              </option>
+            ))}
+          </select>
+          {main && (
+            <video
+              className="w-full aspect-video bg-black"
+              src={`/hwcapture/stream?device=${encodeURIComponent(main)}`}
+              autoPlay
+              muted
+            />
+          )}
+        </div>
+
+        <div>
+          <select
+            className="w-full mb-2"
+            value={wit}
+            onChange={(e) => setWit(e.target.value)}
+          >
+            {devices?.map((d) => (
+              <option key={d.path} value={d.path}>
+                {d.path}
+              </option>
+            ))}
+          </select>
+          {wit && (
+            <video
+              className="w-full aspect-video bg-black"
+              src={`/hwcapture/stream?device=${encodeURIComponent(wit)}`}
+              autoPlay
+              muted
+            />
+          )}
+        </div>
+      </div>
+
+      <button
+        className="btn"
+        onClick={() => startWitness.mutate({ main, witness: wit })}
+      >
+        ⚡ Start 60-s take
+      </button>
+    </div>
   );
 }

--- a/docker/web-app/src/lib/videoApi.ts
+++ b/docker/web-app/src/lib/videoApi.ts
@@ -36,7 +36,8 @@ export const videoApi = {
 
   /* hardware capture helpers */
   listDevices: () => getJson<Device[]>('/hwcapture/devices'),
-  witnessStart: (req: WitnessReq) => postJson<{}>('/hwcapture/witness_record', req),
+  witnessStart: (req: WitnessReq) =>
+    postJson<{ job: string; status: string }>('/hwcapture/witness_record', req),
   vectorSearch: (q: string) => getJson<Asset[]>(`/vector-search?q=${encodeURIComponent(q)}`),
 };
 
@@ -47,4 +48,4 @@ export interface VideoCard { artifact: { path: string }; /* …snip… */ }
 export interface MotionExtractPayload { path: string; sensitivity?: number }
 export interface MotionJob { job_id: string; status: string }
 export interface Device { path: string; width: number; height: number; fps: number }
-export interface WitnessReq { device: string; output: string }
+export interface WitnessReq { main: string; witness: string; duration?: number }

--- a/tests/test_witness_record.py
+++ b/tests/test_witness_record.py
@@ -1,0 +1,59 @@
+"""Tests for witness recording helper."""
+import sys
+import types
+import pytest
+
+# Provide a tiny cv2 shim if OpenCV isn't installed.
+if 'cv2' not in sys.modules:
+    sys.modules['cv2'] = types.SimpleNamespace(
+        VideoCapture=lambda *a, **k: None,
+        VideoWriter=lambda *a, **k: None,
+        VideoWriter_fourcc=lambda *a, **k: 0,
+        destroyAllWindows=lambda: None,
+        imshow=lambda *a, **k: None,
+        waitKey=lambda *a, **k: 0,
+        warpAffine=lambda *a, **k: None,
+    )
+
+from video.modules.hwcapture import hwcapture
+
+
+class _DummyCap:
+    def release(self):
+        pass
+
+
+class _DummyWriter:
+    def write(self, frame):
+        pass
+
+    def release(self):
+        pass
+
+
+def _stub_cv(monkeypatch):
+    monkeypatch.setattr(hwcapture.cv2, "VideoCapture", lambda dev: _DummyCap())
+    monkeypatch.setattr(hwcapture.cv2, "VideoWriter", lambda *a, **k: _DummyWriter())
+    monkeypatch.setattr(hwcapture.cv2, "VideoWriter_fourcc", lambda *a, **k: 0)
+    monkeypatch.setattr(hwcapture.cv2, "destroyAllWindows", lambda: None)
+    class Info:
+        width = 640
+        height = 480
+        fps = 30
+    monkeypatch.setattr(
+        hwcapture.DeviceManager, "get_device_info", lambda dev: Info
+    )
+
+
+def test_record_with_witness_success(monkeypatch):
+    monkeypatch.setattr(hwcapture, "validate_device", lambda d: True)
+    _stub_cv(monkeypatch)
+    hwcapture.record_with_witness("/dev/video0", "/dev/video1", duration=0)
+
+
+def test_record_with_witness_invalid_device(monkeypatch):
+    monkeypatch.setattr(
+        hwcapture, "validate_device", lambda d: d == "/dev/video0"
+    )
+    with pytest.raises(ValueError):
+        hwcapture.record_with_witness("/dev/video0", "/dev/bad", duration=0)

--- a/video/web/templates/partials/_witness_card.html
+++ b/video/web/templates/partials/_witness_card.html
@@ -1,6 +1,18 @@
 <details class="glass-card">
   <summary>🛰️ Witness Record</summary>
   <div class="card-body">
+    <div class="grid-two">
+      <div>
+        <label>Main Device</label>
+        <select id="mainDev" class="capDev"></select>
+        <img id="mainPrev" class="prevImg" alt="main preview" />
+      </div>
+      <div>
+        <label>Witness Device</label>
+        <select id="witDev" class="capDev"></select>
+        <img id="witPrev" class="prevImg" alt="witness preview" />
+      </div>
+    </div>
     <button id="startWitness" class="btn">⚡ Start 60-s take</button>
     <pre id="witResult" class="result-area" style="display:none;"></pre>
   </div>


### PR DESCRIPTION
Milestone: 🧬 Feature Development
Scope: web-app, video-web, tests
Linked Issues: N/A

## Summary
- add device selectors and preview to witness card
- mount React witness recorder with side-by-side previews
- expand video API types for witness recording
- test witness recording success and failure paths

## Testing
- `PYTHONPATH=. pytest tests/test_witness_record.py -q`

## Checklist
- [x] Code is self-contained and idempotent.
- [x] No unnecessary new files or external dependencies.
- [x] Tests added or updated as appropriate.
- [ ] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_68a65e6bd4e88326a938cbc33614ba88