### PR TITLE
feat: add asset picker to ffmpeg console

### DIFF
--- a/js_tests/test_ffmpeg_console_run.py
+++ b/js_tests/test_ffmpeg_console_run.py
@@ -1,0 +1,81 @@
+"""Validate ffmpeg-console.js command execution via Node.js.
+
+Example:
+    pytest js_tests/test_ffmpeg_console_run.py
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def test_ffmpeg_run(tmp_path: Path) -> None:
+    """Ensure the console issues a fetch to /api/v1/ffmpeg."""
+
+    script = tmp_path / "run.js"
+    script.write_text(
+        """
+const assert = require('assert');
+let fetchCalls = [];
+global.fetch = async (url, opts = {}) => {
+  fetchCalls.push({ url, opts });
+  if (url.startsWith('/api/v1/ffmpeg/history')) {
+    return { ok: true, json: async () => [] };
+  }
+  if (url.startsWith('/api/v1/explorer/assets')) {
+    return { ok: true, json: async () => [{ path: '/vid/a.mp4' }] };
+  }
+  if (url === '/api/v1/ffmpeg') {
+    return { ok: true, json: async () => ({ exit: 0, elapsed: 0.1, stdout: 'ok' }) };
+  }
+  return { ok: false, json: async () => ({}) };
+};
+
+class Element {
+  constructor() {
+    this.value = '';
+    this.innerHTML = '';
+    this.textContent = '';
+    this.classList = { add: () => {}, remove: () => {} };
+    this.disabled = false;
+    this.files = [];
+    this._listeners = {};
+    this.style = {};
+  }
+  addEventListener(ev, cb) { this._listeners[ev] = cb; }
+  dispatchEvent(ev) { if (this._listeners[ev.type]) this._listeners[ev.type](ev); }
+  appendChild() {}
+}
+
+const els = {};
+['ff-quick-select','ff-file-input','ff-asset-select','ff-output-name','ff-input','ff-run','ff-history-list','ff-output','ff-clear-file'].forEach(id => { els[id] = new Element(); });
+els['ff-input'].value = 'echo test';
+
+global.document = {
+  addEventListener: (ev, cb) => { if (ev === 'DOMContentLoaded') cb(); },
+  getElementById: (id) => els[id],
+  createElement: () => new Element(),
+};
+
+global.Event = class { constructor(type){ this.type = type; } };
+
+require(require('path').join(process.cwd(), 'video/web/static/components/ffmpeg-console.js'));
+
+(async () => {
+  await new Promise(r => setImmediate(r));
+  els['ff-run'].onclick();
+  await new Promise(r => setImmediate(r));
+  assert(fetchCalls.some(c => c.url === '/api/v1/ffmpeg'));
+})();
+""",
+        encoding="utf-8",
+    )
+
+    repo_root = Path(__file__).resolve().parents[1]
+    result = subprocess.run(
+        ["node", str(script)],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/video/web/static/components/README.md
+++ b/video/web/static/components/README.md
@@ -11,3 +11,12 @@ Reusable ES modules used by the web UI.  Import them from `app.js` or other scri
 import { UploadCard } from './components/upload-card.js'
 ```
 
+### ffmpeg-console.js
+
+Include the FFmpeg card partial and this script; it auto-initializes on load:
+
+```html
+<!-- see templates/partials/_ffmpeg_card.html for markup -->
+<script type="module" src="/static/components/ffmpeg-console.js"></script>
+```
+

--- a/video/web/templates/partials/_ffmpeg_card.html
+++ b/video/web/templates/partials/_ffmpeg_card.html
@@ -8,7 +8,15 @@
       <select id="ff-quick-select" class="form-control"></select>
     </div>
 
-    <!-- 2. Local file picker & Output filename -->
+    <!-- 2. Choose existing asset -->
+    <div class="form-group">
+      <label for="ff-asset-select">Choose Asset</label>
+      <select id="ff-asset-select" class="form-control">
+        <option value="">Loading…</option>
+      </select>
+    </div>
+
+    <!-- 3. Local file picker & Output filename -->
     <div class="grid-two mb-1">
       <div class="form-group">
         <label for="ff-file-input">Select Local File</label>


### PR DESCRIPTION
Milestone: 🧬 Feature Development
Scope: video/web, js_tests
Linked Issues: N/A

## Summary
- hook file picker to retain path and clear asset selection
- add asset dropdown populated from explorer API
- document and test ffmpeg-console usage

## Testing
- ✅ `pytest js_tests/test_ffmpeg_console_run.py -q`
- ⚠️ `pytest js_tests/test_live_preview_fetch.py -q` (TypeError: btn._listeners.click is not a function)

## Checklist
- [x] Code is self-contained and idempotent.
- [x] No unnecessary new files or external dependencies.
- [x] Tests added or updated as appropriate.
- [x] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_68a65eb9e2c88326b91835c089172b24