### PR TITLE
feat(web-app): add motion and live dashboard pages

### DIFF
--- a/docker/web-app/src/app/[tenant]/dashboard/__tests__/LivePage.test.tsx
+++ b/docker/web-app/src/app/[tenant]/dashboard/__tests__/LivePage.test.tsx
@@ -1,0 +1,19 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { renderToString } from 'react-dom/server';
+import LivePage from '../live/page';
+
+test('live page snapshot with device', () => {
+  const html = renderToString(
+    LivePage({ searchParams: { device: 'cam1' } }) as any
+  );
+  assert.equal(
+    html,
+    '<div><h1 class="text-2xl font-semibold mb-4">Live Monitor</h1><img src="http://localhost:8080/live/cam1" alt="live feed cam1"/></div>'
+  );
+});
+
+test('live page shows fallback when no device', () => {
+  const html = renderToString(LivePage({ searchParams: {} }) as any);
+  assert.ok(html.includes('No device selected'));
+});

--- a/docker/web-app/src/app/[tenant]/dashboard/__tests__/MotionPage.test.tsx
+++ b/docker/web-app/src/app/[tenant]/dashboard/__tests__/MotionPage.test.tsx
@@ -1,0 +1,19 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { renderToString } from 'react-dom/server';
+import MotionPage from '../motion/page';
+import { motionExtractor } from '../../../../lib/api';
+
+test('motion page snapshot', async () => {
+  const original = motionExtractor.jobs;
+  motionExtractor.jobs = async () => [{ id: '1', status: 'done' }];
+  try {
+    const html = renderToString(await MotionPage());
+    assert.equal(
+      html,
+      '<div><h1 class="text-2xl font-semibold mb-4">Motion Extractor Jobs</h1><ul class="space-y-2"><li class="p-2 border rounded">done</li></ul></div>'
+    );
+  } finally {
+    motionExtractor.jobs = original;
+  }
+});

--- a/docker/web-app/src/app/[tenant]/dashboard/live/page.tsx
+++ b/docker/web-app/src/app/[tenant]/dashboard/live/page.tsx
@@ -1,8 +1,24 @@
-export default function LiveMonitorPage() {
+// /docker/web-app/src/app/[tenant]/dashboard/live/page.tsx
+// Streams live video from a selected device or shows a fallback message.
+import { apiUrl } from '../../../../lib/networkConfig';
+
+export const metadata = { title: 'Live • That DAM Toolbox' };
+
+export default function LivePage({ searchParams }: { searchParams: { device?: string } }) {
+  const device = searchParams?.device;
+  if (!device) {
+    return (
+      <div>
+        <h1 className="text-2xl font-semibold mb-4">Live Monitor</h1>
+        <p className="text-gray-500">No device selected</p>
+      </div>
+    );
+  }
+  const src = apiUrl(`/live/${device}`);
   return (
-    <section className="p-8">
-      <h2 className="text-3xl font-bold mb-4">Live Monitor</h2>
-      <p>Monitor live video feeds in real time.</p>
-    </section>
+    <div>
+      <h1 className="text-2xl font-semibold mb-4">Live Monitor</h1>
+      <img src={src} alt={`live feed ${device}`} />
+    </div>
   );
 }

--- a/docker/web-app/src/app/[tenant]/dashboard/motion/page.tsx
+++ b/docker/web-app/src/app/[tenant]/dashboard/motion/page.tsx
@@ -1,5 +1,30 @@
-import MotionExtract from '@/components/tools/MotionExtract'
+// /docker/web-app/src/app/[tenant]/dashboard/motion/page.tsx
+// Lists motion extractor jobs and their statuses.
+import { motionExtractor } from '../../../../lib/api';
 
-export default function MotionPage() {
-  return <MotionExtract />
+export const metadata = { title: 'Motion • That DAM Toolbox' };
+
+export default async function MotionPage() {
+  try {
+    const jobs = await motionExtractor.jobs();
+    return (
+      <div>
+        <h1 className="text-2xl font-semibold mb-4">Motion Extractor Jobs</h1>
+        <ul className="space-y-2">
+          {jobs.map((job: any, idx: number) => (
+            <li key={job.id ?? idx} className="p-2 border rounded">
+              {job.status || JSON.stringify(job)}
+            </li>
+          ))}
+        </ul>
+      </div>
+    );
+  } catch {
+    return (
+      <div>
+        <h1 className="text-2xl font-semibold mb-4">Motion Extractor Jobs</h1>
+        <p className="text-red-500">Unable to fetch job status</p>
+      </div>
+    );
+  }
 }

--- a/docker/web-app/src/lib/api/index.ts
+++ b/docker/web-app/src/lib/api/index.ts
@@ -43,6 +43,11 @@ export const videoApi = {
     getJson<unknown[]>(`/video/search?q=${encodeURIComponent(q)}`),
 };
 
+// Motion extractor job status
+export const motionExtractor = {
+  jobs: () => getJson<unknown[]>('/motion_extractor'),
+};
+
 // API gateway: credentials, webhooks, billing
 export const apiGateway = {
   credentials: () => getJson<unknown[]>('/credentials'),


### PR DESCRIPTION
Milestone: 🧬 Feature Development
Scope: web-app
Linked Issues: #0

## Summary
- add motion extractor dashboard page and API client
- stream selected device on new live monitor page
- cover motion and live pages with snapshot tests

## Testing
- `npm test` *(fails: Could not find '/workspace/ThatDAMToolbox/docker/web-app/.tmp-test/**/*.test.js')*
- `npx tsc -p tsconfig.test.json && node --test $(find .tmp-test -name '*.test.js')`

## Checklist
- [ ] Code is self-contained and idempotent.
- [ ] No unnecessary new files or external dependencies.
- [ ] Tests added or updated as appropriate.
- [ ] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_68a65ebbbe188326a31fde3878ab38ff