### PR TITLE
refactor: replace explorer-pane with React DAM explorer

### DIFF
--- a/video/web/static/components/__tests__/upload-card.test.js
+++ b/video/web/static/components/__tests__/upload-card.test.js
@@ -1,0 +1,52 @@
+// Tests for UploadCard refresh event
+// Example: node --test upload-card.test.js
+import test from 'node:test';
+import assert from 'node:assert';
+
+// stub minimal DOM for UploadCard
+const inputEl = { addEventListener: () => {} };
+const listEl = { appendChild: () => {} };
+const cardEl = {
+  querySelector: (sel) => (sel === '#file-input' ? inputEl : listEl)
+};
+
+global.document = {
+  getElementById: () => cardEl,
+  addEventListener: () => {},
+  createElement: () => ({ textContent: '' })
+};
+
+global.window = {
+  dispatchEvent: (evt) => events.push(evt),
+  addEventListener: () => {}
+};
+
+const events = [];
+
+// stub timer and network
+let clearCalled = false;
+
+global.fetch = async () => ({
+  ok: true,
+  json: async () => ({ filename: 'f', progress: 1, status: 'done' })
+});
+
+global.Event = class { constructor(type){ this.type = type; } };
+
+const UploadCard = (await import('../upload-card.js')).default;
+
+test('poll dispatches explorer refresh event', async () => {
+  // wrap setInterval to run callback immediately and wait for completion
+  const done = new Promise(resolve => {
+    global.setInterval = (fn, t) => { fn().then(resolve); return 0; };
+  });
+  global.clearInterval = () => { clearCalled = true; };
+
+  const uc = new UploadCard();
+  const li = { textContent: '' };
+  uc.poll('123', li);
+  await done;
+  assert.strictEqual(clearCalled, true);
+  assert.strictEqual(events.length, 1);
+  assert.strictEqual(events[0].type, 'explorer:refresh');
+});

--- a/video/web/static/components/upload-card.js
+++ b/video/web/static/components/upload-card.js
@@ -52,7 +52,8 @@ export default class UploadCard {
         if (j.status === 'done') {
           clearInterval(timer);
           li.textContent = `${j.filename} – ✅`;
-          document.querySelector('explorer-pane')?.refresh();
+          // Notify DAM Explorer to refresh its asset list
+          window.dispatchEvent(new Event('explorer:refresh'));
         } else if (j.status === 'error') {
           clearInterval(timer);
           li.textContent = `${j.filename} – ❌ ${j.error || 'Unknown error'}`;


### PR DESCRIPTION
Milestone: 🧬 Feature Development
Scope: video/web
Linked Issues: 

## Summary
- replace legacy explorer-pane refresh call with event for React DAM explorer
- add node test covering upload card refresh event

## Testing
- `node --test video/web/static/components/__tests__/live-preview.test.js video/web/static/components/__tests__/upload-card.test.js`
- `PYTHONPATH=. pytest tests/test_dam_explorer_asset.py js_tests/test_live_preview_fetch.py -q` *(fails: Command '['stat', '-f', '-c', '%T', '/data/db']' returned non-zero exit status 1)*

## Checklist
- [x] Code is self-contained and idempotent.
- [x] No unnecessary new files or external dependencies.
- [x] Tests added or updated as appropriate.
- [ ] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_68a65f0788cc8326a7c68bc63835c0a3