### PR TITLE
feat: introduce tenant-aware ports

### DIFF
--- a/video/core/ingest.py
+++ b/video/core/ingest.py
@@ -22,6 +22,8 @@ import shutil
 from pathlib import Path
 from typing import Iterable, Final, Sequence
 
+from .ports import UsageMeterPort
+
 from video.config import MEDIA_ROOT
 from video.probe  import probe_media          # ffprobe helper
 
@@ -62,6 +64,7 @@ def ingest_files(
     paths: Iterable[str | Path],
     *,
     batch_name: str | None = None,
+    usage_meter: "UsageMeterPort" | None = None,
 ) -> int:
     """
     Move each *path* to the canonical store and register it in the DB.
@@ -99,6 +102,8 @@ def ingest_files(
             )
 
             processed += 1
+            if usage_meter:
+                usage_meter.record_ingest()
 
         except Exception as exc:                  # noqa: BLE001
             _LOG.exception("Ingest failed for %s: %s", p, exc)

--- a/video/core/ports.py
+++ b/video/core/ports.py
@@ -1,0 +1,81 @@
+"""Core ports providing tenant-aware helpers.
+
+Example:
+    port = RelationalStorePort(lambda: sqlite3.connect("/tmp/db.sqlite"), "t1")
+    port.execute("SELECT * FROM items")
+"""
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from typing import Any, Callable, Sequence
+
+from video.eventbus import publish
+
+
+def tenant_prefix(tenant_id: str, key: str) -> str:
+    """Prefix ``key`` with ``tenant/{id}`` for isolation."""
+    return f"tenant/{tenant_id}/{key}"
+
+
+class RelationalStorePort:
+    """Wrap SQL execution and automatically scope by ``tenant_id``."""
+
+    def __init__(self, connect: Callable[[], sqlite3.Connection], tenant_id: str) -> None:
+        self._connect = connect
+        self.tenant_id = tenant_id
+
+    def execute(self, sql: str, params: Sequence[Any] | None = None):
+        params = list(params or [])
+        normalized = sql.strip().lower()
+
+        if normalized.startswith("select"):
+            if "where" in normalized:
+                sql += " AND tenant_id = ?"
+            else:
+                sql += " WHERE tenant_id = ?"
+            params.append(self.tenant_id)
+        elif normalized.startswith("insert"):
+            idx = normalized.find("values")
+            cols_part = sql[:idx]
+            vals_part = sql[idx:]
+            cols_part = cols_part.replace("(", "(tenant_id, ", 1)
+            vals_part = vals_part.replace("VALUES (", "VALUES (?, ", 1)
+            sql = cols_part + vals_part
+            params.insert(0, self.tenant_id)
+        else:
+            if "where" in normalized:
+                sql += " AND tenant_id = ?"
+            else:
+                sql += " WHERE tenant_id = ?"
+            params.append(self.tenant_id)
+
+        with self._connect() as cx:
+            return cx.execute(sql, params)
+
+
+@dataclass
+class UsageLimits:
+    ingest: int = 0
+    transcode: int = 0
+
+
+class UsageMeterPort:
+    """Track per-tenant usage and emit limit events."""
+
+    def __init__(self, tenant_id: str, limits: UsageLimits) -> None:
+        self.tenant_id = tenant_id
+        self.limits = limits
+        self._usage = {"ingest": 0, "transcode": 0}
+
+    def record_ingest(self, count: int = 1) -> None:
+        self._usage["ingest"] += count
+        if self.limits.ingest and self._usage["ingest"] > self.limits.ingest:
+            publish("tenant.limit", {"tenant_id": self.tenant_id, "metric": "ingest"})
+            raise RuntimeError("ingest limit exceeded")
+
+    def record_transcode(self, count: int = 1) -> None:
+        self._usage["transcode"] += count
+        if self.limits.transcode and self._usage["transcode"] > self.limits.transcode:
+            publish("tenant.limit", {"tenant_id": self.tenant_id, "metric": "transcode"})
+            raise RuntimeError("transcode limit exceeded")

--- a/video/core/transcode.py
+++ b/video/core/transcode.py
@@ -10,10 +10,12 @@ import shutil
 import subprocess
 from typing import Literal
 
+from .ports import UsageMeterPort
+
 __all__ = ["transcode_sw"]
 
 
-def transcode_sw(src: str, dst: str, vcodec: Literal["h264", "hevc"] = "h264") -> None:
+def transcode_sw(src: str, dst: str, vcodec: Literal["h264", "hevc"] = "h264", usage_meter: UsageMeterPort | None = None) -> None:
     """Transcode ``src`` to ``dst`` using ffmpeg (CPU).
 
     Raises ``RuntimeError`` if ffmpeg is not available.
@@ -34,3 +36,5 @@ def transcode_sw(src: str, dst: str, vcodec: Literal["h264", "hevc"] = "h264") -
         dst,
     ]
     subprocess.check_call(cmd)
+    if usage_meter:
+        usage_meter.record_transcode()

--- a/video/db.py
+++ b/video/db.py
@@ -17,6 +17,7 @@ from typing     import Optional, List, Dict, Any
 import fcntl  # Linux-only; use portalocker for cross-platform if you need Mac/Windows
 
 from .config import DB_PATH                     # resolved by video.config
+from video.core.ports import RelationalStorePort
 
 # ─────────────────────────────────────────────────────────────────────────────
 DB_FILE        = Path(os.getenv("VIDEO_DB_PATH", str(DB_PATH))).expanduser()
@@ -364,6 +365,10 @@ class MediaDB:
         # Always ensure FTS is rebuilt after destructive ops
         self._repair_fts()
         return total
+
+    def port(self, tenant_id: str) -> RelationalStorePort:
+        """Return a tenant-scoped relational store port."""
+        return RelationalStorePort(self.conn, tenant_id)
 
 
     # Only _repair_fts() implementation shown – keep the rest of your helpers

--- a/video/modules/dam/models/embeddings.py
+++ b/video/modules/dam/models/embeddings.py
@@ -20,6 +20,7 @@ import open_clip
 import cv2
 
 from .hierarchy import VideoSlice, HierarchyManager
+from video.core.ports import tenant_prefix
 
 logger = logging.getLogger(__name__)
 
@@ -308,17 +309,18 @@ class EmbeddingGenerator:
         
         return vectors
     
-    def get_cache_key(self, path: str, slice_obj: VideoSlice) -> str:
+    def get_cache_key(self, path: str, slice_obj: VideoSlice, tenant_id: str = "default") -> str:
         """Generate cache key for embedding."""
         file_hash = hash(path)  # Simplified hash
-        return f"{file_hash}_{slice_obj.cache_key}_{slice_obj.level}"
-    
-    async def get_cached_embedding(self, path: str, slice_obj: VideoSlice) -> Optional[np.ndarray]:
+        key = f"{file_hash}_{slice_obj.cache_key}_{slice_obj.level}"
+        return tenant_prefix(tenant_id, key)
+
+    async def get_cached_embedding(self, path: str, slice_obj: VideoSlice, tenant_id: str = "default") -> Optional[np.ndarray]:
         """Get cached embedding if available."""
-        cache_key = self.get_cache_key(path, slice_obj)
+        cache_key = self.get_cache_key(path, slice_obj, tenant_id)
         return self.embedding_cache.get(cache_key)
-    
-    async def cache_embedding(self, path: str, slice_obj: VideoSlice, embedding: np.ndarray):
+
+    async def cache_embedding(self, path: str, slice_obj: VideoSlice, embedding: np.ndarray, tenant_id: str = "default"):
         """Cache embedding for future use."""
-        cache_key = self.get_cache_key(path, slice_obj)
+        cache_key = self.get_cache_key(path, slice_obj, tenant_id)
         self.embedding_cache[cache_key] = embedding

--- a/video/tests/test_ports.py
+++ b/video/tests/test_ports.py
@@ -1,0 +1,49 @@
+"""Tests for tenant-aware ports."""
+import sqlite3
+import pytest
+
+from video.core.ports import (
+    RelationalStorePort,
+    UsageLimits,
+    UsageMeterPort,
+    tenant_prefix,
+)
+
+
+def test_relational_store_port_scopes_queries(tmp_path):
+    db_file = tmp_path / "db.sqlite"
+
+    def connect():
+        return sqlite3.connect(db_file)
+
+    with connect() as cx:
+        cx.execute("CREATE TABLE items (tenant_id TEXT, value TEXT)")
+        cx.execute("INSERT INTO items VALUES ('t1', 'a')")
+        cx.execute("INSERT INTO items VALUES ('t2', 'b')")
+
+    port = RelationalStorePort(connect, "t1")
+    rows = port.execute("SELECT value FROM items").fetchall()
+    assert rows == [("a",)]
+    port.execute("INSERT INTO items (value) VALUES (?)", ("c",))
+    with connect() as cx:
+        vals = cx.execute("SELECT tenant_id, value FROM items WHERE tenant_id='t1'").fetchall()
+        assert ("t1", "c") in vals
+
+
+def test_usage_meter_port_isolated(monkeypatch):
+    events = []
+    monkeypatch.setattr("video.core.ports.publish", lambda topic, payload: events.append((topic, payload)))
+
+    m1 = UsageMeterPort("t1", UsageLimits(ingest=1))
+    m1.record_ingest()
+    with pytest.raises(RuntimeError):
+        m1.record_ingest()
+    assert events[0][1]["tenant_id"] == "t1"
+
+    m2 = UsageMeterPort("t2", UsageLimits(ingest=1))
+    m2.record_ingest()
+    assert len(events) == 1
+
+
+def test_tenant_prefix():
+    assert tenant_prefix("42", "key") == "tenant/42/key"


### PR DESCRIPTION
Milestone: 🧬 Feature Development
Scope: video
Linked Issues: 

## Summary
- add tenant-aware RelationalStorePort and UsageMeterPort
- auto-scope ingest and transcode with usage meter
- namespace cache paths by tenant

## Testing
- `PYTHONPATH=. pytest video/tests/test_ports.py video/tests/test_transcode.py -q`

## Checklist
- [x] Code is self-contained and idempotent.
- [x] No unnecessary new files or external dependencies.
- [x] Tests added or updated as appropriate.
- [ ] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_68a662e5e2048326a375dca0bd284ca1