### PR TITLE
feat(web-app): add tenancy proxy route

### DIFF
--- a/docker/web-app/README.md
+++ b/docker/web-app/README.md
@@ -263,6 +263,7 @@ Create `/web-app/.env.local` for local development:
 ```env
 NEXT_PUBLIC_API_BASE_URL=http://localhost:8080
 NEXT_PUBLIC_WS_URL=ws://localhost:8080/ws
+TENANCY_URL=http://localhost:8080/api/tenancy
 NODE_ENV=development
 ```
 

--- a/docker/web-app/src/app/api/__tests__/tenancy.test.ts
+++ b/docker/web-app/src/app/api/__tests__/tenancy.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Tests for the /api/tenancy route.
+ * Run with: npm test
+ */
+import assert from 'node:assert';
+import test from 'node:test';
+import { POST } from '../tenancy/route';
+
+test('POST /api/tenancy returns tenant credentials on success', async t => {
+  const originalFetch = global.fetch;
+  t.after(() => {
+    global.fetch = originalFetch;
+  });
+  process.env.TENANCY_URL = 'http://tenancy.local';
+
+  const body = { name: 'Demo' };
+  global.fetch = async (url, init) => {
+    assert.strictEqual(url, process.env.TENANCY_URL);
+    assert.strictEqual(init?.method, 'POST');
+    assert.deepStrictEqual(JSON.parse(String(init?.body)), body);
+    return new Response(JSON.stringify({ tenantId: 't1', token: 'tok' }), {
+      status: 200,
+    });
+  };
+
+  const req = new Request('http://localhost/api/tenancy', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+  const res = await POST(req);
+  assert.strictEqual(res.status, 200);
+  const data = await res.json();
+  assert.deepStrictEqual(data, { tenantId: 't1', token: 'tok' });
+});
+
+test('POST /api/tenancy surfaces upstream errors', async t => {
+  const originalFetch = global.fetch;
+  t.after(() => {
+    global.fetch = originalFetch;
+  });
+  process.env.TENANCY_URL = 'http://tenancy.local';
+
+  global.fetch = async () =>
+    new Response(JSON.stringify({ error: 'bad request' }), { status: 400 });
+
+  const req = new Request('http://localhost/api/tenancy', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name: 'Demo' }),
+  });
+
+  const res = await POST(req);
+  assert.strictEqual(res.status, 400);
+  const data = await res.json();
+  assert.ok(data.error.includes('bad request'));
+});

--- a/docker/web-app/src/app/api/tenancy/route.ts
+++ b/docker/web-app/src/app/api/tenancy/route.ts
@@ -1,0 +1,50 @@
+/**
+ * POST /api/tenancy
+ * Forwards tenant creation requests to the Tenancy service.
+ * Example:
+ * curl -X POST http://localhost:3000/api/tenancy \\
+ *   -H 'Content-Type: application/json' \\
+ *   -d '{"name":"Demo","email":"demo@example.com"}'
+ */
+import { NextResponse } from 'next/server';
+
+export async function POST(req: Request) {
+  const url = process.env.TENANCY_URL;
+  if (!url) {
+    return NextResponse.json(
+      { error: 'TENANCY_URL not configured' },
+      { status: 500 },
+    );
+  }
+
+  try {
+    const payload = await req.json();
+    const upstream = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+
+    if (!upstream.ok) {
+      let message = upstream.statusText;
+      try {
+        const err = await upstream.json();
+        message = err.error || message;
+      } catch {
+        // use statusText
+      }
+      return NextResponse.json(
+        { error: `Tenancy service error: ${message}` },
+        { status: upstream.status },
+      );
+    }
+
+    const data = await upstream.json();
+    return NextResponse.json({ tenantId: data.tenantId, token: data.token });
+  } catch (err) {
+    return NextResponse.json(
+      { error: 'Failed to contact tenancy service' },
+      { status: 502 },
+    );
+  }
+}

--- a/docker/web-app/tsconfig.test.json
+++ b/docker/web-app/tsconfig.test.json
@@ -18,6 +18,7 @@
     "src/app/*/dashboard/__tests__/**/*.tsx",
     "src/app/__tests__/**/*.tsx",
     "src/app/assets/__tests__/**/*.tsx",
+    "src/app/api/__tests__/**/*.ts",
     "src/app/__tests__/**/*.tsx",
     "src/types/**/*.d.ts",
     "src/components/tools/FFmpegConsole.tsx",


### PR DESCRIPTION
Milestone: 🧬 Feature Development
Scope: web-app
Linked Issues: N/A

## Summary
- forward POST /api/tenancy to Tenancy service and surface errors
- test success and error paths for tenancy proxy
- document TENANCY_URL and enable API tests in tsc config

## Testing
- `npm test` *(fails to expand glob in CI, tests run manually)*
- `node --test $(find .tmp-test -name '*.test.js')`

## Checklist
- [x] Code is self-contained and idempotent.
- [x] No unnecessary new files or external dependencies.
- [x] Tests added or updated as appropriate.
- [x] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_68a66b8b55308326a8f8ed8c5ab96d02