### PR TITLE
feat: auth-bridge resolves membership via Tenancy service

### DIFF
--- a/docker/compose/docker-compose.auth-auth0.yaml
+++ b/docker/compose/docker-compose.auth-auth0.yaml
@@ -42,6 +42,7 @@ services:
       AUTH_REDIRECT_BASE: "${AUTH_REDIRECT_BASE:-http://localhost:8081}"
       AUTH_COOKIE_DOMAIN: "${AUTH_COOKIE_DOMAIN:-localhost}"
       AUTH_ALLOWED_ORIGINS: "${AUTH_ALLOWED_ORIGINS:-http://localhost:3000}"
+      TENANCY_URL: "${TENANCY_URL:-http://tenancy:8082}"
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://localhost:8081/health"]
       interval: 10s

--- a/docker/compose/docker-compose.auth-keycloak.yaml
+++ b/docker/compose/docker-compose.auth-keycloak.yaml
@@ -62,6 +62,7 @@ services:
       AUTH_REDIRECT_BASE: "${AUTH_REDIRECT_BASE:-http://localhost:8081}"
       AUTH_COOKIE_DOMAIN: "${AUTH_COOKIE_DOMAIN:-localhost}"
       AUTH_ALLOWED_ORIGINS: "${AUTH_ALLOWED_ORIGINS:-http://localhost:3000}"
+      TENANCY_URL: "${TENANCY_URL:-http://tenancy:8082}"
     depends_on:
       keycloak:
         condition: service_healthy

--- a/docs/TECHNICAL/AUTH_FLIP.md
+++ b/docs/TECHNICAL/AUTH_FLIP.md
@@ -31,11 +31,13 @@ Use the root `docker-compose.yaml` with profiles when you want the bridge and Id
 # Auth0
 export COMPOSE_PROFILES=auth0
 export OIDC_PROVIDER=auth0
+export TENANCY_URL=http://tenancy:8082
 docker compose up -d --build auth-bridge
 
 # Keycloak
 export COMPOSE_PROFILES=keycloak
 export OIDC_PROVIDER=keycloak
+export TENANCY_URL=http://tenancy:8082
 docker compose up -d --build keycloak auth-bridge
 ```
 

--- a/host/services/auth-bridge/AGENTS.md
+++ b/host/services/auth-bridge/AGENTS.md
@@ -6,4 +6,5 @@ Scope: Minimal HTTP bridge exposing Auth0 or Keycloak auth endpoints.
 - Respect `OIDC_*` env vars; default provider is Auth0.
 - Expose `/health`, `/session/me`, and login/logout routes; document additions.
 - Keep internal logic under `internal/`; avoid cross-service imports.
+- `TENANCY_URL` enables membership lookup; handlers must degrade gracefully if unset.
 - Test with `go test ./...` and update README for new config.

--- a/host/services/auth-bridge/README.md
+++ b/host/services/auth-bridge/README.md
@@ -24,6 +24,7 @@ OIDC_PROVIDER=auth0 go run ./cmd/auth-bridge
 - `OIDC_SCOPES` – requested scopes (default `openid profile email`)
 - `AUTH_REDIRECT_BASE` – public URL for callbacks (default `http://localhost:8081`)
 - `AUTH_COOKIE_DOMAIN` – cookie domain (default `localhost`)
+- `TENANCY_URL` – base URL for Tenancy service to resolve memberships
 - `ADDR` – listen address (default `:8081`)
 
 See [docs/TECHNICAL/AUTH_FLIP.md](../../docs/TECHNICAL/AUTH_FLIP.md) for compose profiles.

--- a/host/services/auth-bridge/cmd/auth-bridge/main_test.go
+++ b/host/services/auth-bridge/cmd/auth-bridge/main_test.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/Cdaprod/ThatDamToolbox/host/services/auth-bridge/internal/config"
@@ -12,6 +14,14 @@ import (
 
 // TestEndpoints ensures basic endpoints respond.
 func TestEndpoints(t *testing.T) {
+	tenancy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"m1","tenant_id":"t1","user_id":"demo","role":"OWNER"}`))
+	}))
+	defer tenancy.Close()
+	os.Setenv("TENANCY_URL", tenancy.URL)
+	defer os.Unsetenv("TENANCY_URL")
+
 	cfg := config.Load()
 	mux := server.BuildMux(cfg)
 	srv := httptest.NewServer(mux)
@@ -23,6 +33,14 @@ func TestEndpoints(t *testing.T) {
 
 	if resp, err := http.Get(srv.URL + "/session/me"); err != nil || resp.StatusCode != http.StatusOK {
 		t.Fatalf("session: %v status=%d", err, resp.StatusCode)
+	} else {
+		var payload map[string]any
+		if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if _, ok := payload["membership"]; !ok {
+			t.Fatalf("expected membership in response")
+		}
 	}
 
 	body := bytes.NewBufferString(`{"profile":"capture"}`)

--- a/host/services/auth-bridge/internal/config/config.go
+++ b/host/services/auth-bridge/internal/config/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	RedirectBase   string
 	CookieDomain   string
 	AllowedOrigins []string // reserved for future CORS work
+	TenancyURL     string
 	Addr           string
 }
 
@@ -38,6 +39,7 @@ func Load() Config {
 		Scopes:       env("OIDC_SCOPES", "openid profile email"),
 		RedirectBase: env("AUTH_REDIRECT_BASE", "http://localhost:8081"),
 		CookieDomain: env("AUTH_COOKIE_DOMAIN", "localhost"),
+		TenancyURL:   env("TENANCY_URL", ""),
 		Addr:         env("ADDR", ":8081"),
 	}
 }

--- a/host/services/auth-bridge/internal/httpapi/session.go
+++ b/host/services/auth-bridge/internal/httpapi/session.go
@@ -5,20 +5,53 @@ import (
 	"encoding/json"
 	"net/http"
 	"time"
+
+	"github.com/Cdaprod/ThatDamToolbox/host/services/auth-bridge/internal/config"
 )
 
-// SessionMeHandler returns a placeholder normalized profile.
+// membership mirrors the Tenancy service response.
+type membership struct {
+	ID       string `json:"id"`
+	TenantID string `json:"tenant_id"`
+	UserID   string `json:"user_id"`
+	Role     string `json:"role"`
+}
+
+// SessionMeHandler returns a normalized profile and optional membership info.
 // Example:
 //
-//	curl http://localhost:8081/session/me
-func SessionMeHandler(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "application/json")
-	resp := map[string]any{
-		"sub":   "placeholder",
-		"email": "demo@example.com",
-		"name":  "Demo User",
-		"roles": []string{"viewer"},
-		"exp":   time.Now().Add(1 * time.Hour).Unix(),
+//	curl -H "X-User-ID: demo" http://localhost:8081/session/me
+func SessionMeHandler(cfg config.Config) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		sub := r.Header.Get("X-User-ID")
+		if sub == "" {
+			sub = "demo"
+		}
+
+		resp := map[string]any{
+			"sub":   sub,
+			"email": sub + "@example.com",
+			"name":  "Demo User",
+			"roles": []string{"viewer"},
+			"exp":   time.Now().Add(1 * time.Hour).Unix(),
+		}
+
+		if cfg.TenancyURL != "" {
+			req, err := http.NewRequest(http.MethodPost, cfg.TenancyURL+"/login", nil)
+			if err == nil {
+				req.Header.Set("X-User-ID", sub)
+				if tr, err := http.DefaultClient.Do(req); err == nil && tr.StatusCode == http.StatusOK {
+					defer tr.Body.Close()
+					var m membership
+					if json.NewDecoder(tr.Body).Decode(&m) == nil {
+						resp["membership"] = m
+					}
+				}
+			}
+		}
+
+		_ = json.NewEncoder(w).Encode(resp)
 	}
-	_ = json.NewEncoder(w).Encode(resp)
 }

--- a/host/services/auth-bridge/internal/server/server.go
+++ b/host/services/auth-bridge/internal/server/server.go
@@ -14,7 +14,7 @@ func BuildMux(cfg config.Config) *http.ServeMux {
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("/health", httpapi.HealthHandler)
-	mux.HandleFunc("/session/me", httpapi.SessionMeHandler)
+	mux.HandleFunc("/session/me", httpapi.SessionMeHandler(cfg))
 
 	store := runners.NewMemoryStore()
 	mux.HandleFunc("/runners/register", runners.RegisterHandler(store))


### PR DESCRIPTION
Milestone: 🧬 Feature Development
Scope: auth-bridge, docker, docs
Linked Issues: none

## Summary
- add `TENANCY_URL` to auth-bridge config and session handler
- call Tenancy `/login` to embed membership info
- expose tenancy URL in auth compose profiles and docs

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68a65186e63883269338df8ee0293e12