### PR TITLE
fix: make minio healthcheck idempotent

### DIFF
--- a/docker/compose/docker-compose.minio.yaml
+++ b/docker/compose/docker-compose.minio.yaml
@@ -59,8 +59,7 @@ services:
     healthcheck:
       test: >
         CMD-SHELL
-        mc alias set hc http://localhost:9000 "$$MINIO_ROOT_USER" "$$MINIO_ROOT_PASSWORD" >/dev/null 2>&1
-        && mc admin info hc >/dev/null 2>&1
+        mc alias set hc http://localhost:9000 "$$MINIO_ROOT_USER" "$$MINIO_ROOT_PASSWORD" >/dev/null 2>&1 || true; mc admin info hc >/dev/null 2>&1
       interval: 10s
       timeout: 5s
       retries: 12


### PR DESCRIPTION
Milestone: 🧬 Feature Development
Scope: docker
Linked Issues: N/A

## Summary
- allow MinIO healthcheck alias to exist without failing

## Testing
- `pip install -e .`
- `pytest tests/test_minio_entrypoint.py script_tests/test_minio_entrypoint.py -q` *(fails: Command '['stat', '-f', '-c', '%T', '/data/db']' returned non-zero exit status 1.)*

------
https://chatgpt.com/codex/tasks/task_e_68a67d44f534832696e38abec6811707