### PR TITLE
fix: resolve weaviate port conflict

### DIFF
--- a/deploy_tests/test_port_conflicts.py
+++ b/deploy_tests/test_port_conflicts.py
@@ -1,0 +1,28 @@
+"""Detect duplicate host ports in default compose stack.
+
+Example:
+    pytest deploy_tests/test_port_conflicts.py::test_no_host_port_conflicts
+"""
+
+import re
+import subprocess
+
+import pytest
+
+
+def test_no_host_port_conflicts():
+    """Ensure docker-compose exposes unique host ports."""
+    cmd = ["docker", "compose", "config"]
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True)
+    except FileNotFoundError:
+        pytest.skip("docker not installed")
+    assert proc.returncode == 0, proc.stderr
+
+    ports = {}
+    for line in proc.stdout.splitlines():
+        match = re.search(r"published:\s*(\d+)", line)
+        if match:
+            port = int(match.group(1))
+            assert port not in ports, f"duplicate host port {port}"
+            ports[port] = True

--- a/docker/compose/docker-compose.video-api.yaml
+++ b/docker/compose/docker-compose.video-api.yaml
@@ -89,7 +89,7 @@ services:
       # VIDEO_STORAGE:  "sqlite"                      # Default (no env needed)
       # VIDEO_STORAGE:  "faiss"                       # Use Faiss vector index
       # VIDEO_STORAGE:  "weaviate"                    # Use Weaviate backend
-      WEAVIATE_URL:   "http://localhost:8082"         # For Weaviate backend:
+      WEAVIATE_URL:   "http://localhost:8083"         # For Weaviate backend:
       MINIO_ENDPOINT: "http://localhost:9000"         # Optional if your code needs it
 
       # --- Event bus + integrations -------------

--- a/docker/compose/docker-compose.weaviate.yaml
+++ b/docker/compose/docker-compose.weaviate.yaml
@@ -7,7 +7,7 @@ services:
     container_name: thatdamtoolbox-weaviate
     command: ["--host","0.0.0.0","--port","8080","--scheme","http"]
     ports:
-      - "8082:8080"  # Weaviate REST
+      - "8083:8080"  # Weaviate REST
       - "50051:50051" # (gRPC, optional)
     environment:
       QUERY_DEFAULTS_LIMIT:                      "25"

--- a/docker/weaviate/README.md
+++ b/docker/weaviate/README.md
@@ -86,14 +86,14 @@ How to Use
 
 Deploy Schema
 
-You can create this schema with a script using the Weaviate Python client or via a POST to http://localhost:8081/v1/schema.
+You can create this schema with a script using the Weaviate Python client or via a POST to http://localhost:8083/v1/schema.
 
 Example (Python, run in your dev container):
 
 import weaviate
 import json
 
-client = weaviate.Client("http://localhost:8081")
+client = weaviate.Client("http://localhost:8083")
 
 with open("scripts/weaviate/schema.json") as f:
     schema = json.load(f)

--- a/docs/TODO/MINIO-WEAVIATE-PG-POST-BLOBSTORE.md
+++ b/docs/TODO/MINIO-WEAVIATE-PG-POST-BLOBSTORE.md
@@ -127,7 +127,7 @@ services:
     image: semitechnologies/weaviate:latest
     container_name: thatdamtoolbox-weaviate
     command: ["--host","0.0.0.0","--port","8080","--scheme","http"]
-    ports: ["8082:8080","50051:50051"]
+    ports: ["8083:8080","50051:50051"]
     environment:
       QUERY_DEFAULTS_LIMIT: "25"
       DEFAULT_VECTORIZER_MODULE: "none"


### PR DESCRIPTION
Milestone: 🧬 Feature Development
Scope: docker, docs, tests
Linked Issues: 

## Summary
- expose Weaviate on host port 8083 to avoid tenancy conflict
- point video-api and docs to the new Weaviate port
- add regression test to catch duplicate host ports in compose files

## Testing
- `pytest deploy_tests -q` *(fails: docker/compose/docker-compose.capture.yaml missing)*
- `pytest deploy_tests/test_port_conflicts.py -q` *(skipped: docker not installed)*
- `pytest deploy_tests/test_media_api_compose.py -q` *(skipped: docker not installed)*

## Checklist
- [x] Code is self-contained and idempotent.
- [x] No unnecessary new files or external dependencies.
- [x] Tests added or updated as appropriate.
- [x] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_68a72e725ee4832688862b2a4ad1351f