### PR TITLE
feat(web-app): integrate next-themes for multi-scheme theming

### DIFF
--- a/docker/web-app/package.json
+++ b/docker/web-app/package.json
@@ -30,6 +30,7 @@
     "lucide-react": "^0.357.0",
     "mitt": "^3.0.1",
     "next": "14.0.4",
+    "next-themes": "^0.2.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-icons": "^4.10.1",

--- a/docker/web-app/src/components/TopBar.tsx
+++ b/docker/web-app/src/components/TopBar.tsx
@@ -5,10 +5,12 @@ import clsx from 'clsx'
 import { Menu, X } from 'lucide-react'
 import { useSidebar } from '../hooks/useSidebar'
 import { useModal } from '@/providers/ModalProvider'
+import { useTheme, AVAILABLE_SCHEMES, ColorScheme } from '@/context/ThemeContext'
 
 export default function TopBar() {
   const { collapsed, setCollapsed } = useSidebar()
   const { openModal } = useModal()
+  const { scheme, setScheme } = useTheme()
 
   return (
     <header
@@ -31,8 +33,18 @@ export default function TopBar() {
         </a>
       </div>
 
-      {/* right – placeholder for future buttons */}
+      {/* right – explorer & theme */}
       <nav className="flex items-center gap-4">
+        <select
+          aria-label="Select color scheme"
+          value={scheme}
+          onChange={e => setScheme(e.target.value as ColorScheme)}
+          className="input text-sm"
+        >
+          {AVAILABLE_SCHEMES.map(opt => (
+            <option key={opt} value={opt}>{opt}</option>
+          ))}
+        </select>
         <button
           type="button"
           onClick={() => openModal('dam-explorer')}

--- a/docker/web-app/src/context/ThemeContext.tsx
+++ b/docker/web-app/src/context/ThemeContext.tsx
@@ -1,24 +1,33 @@
 // /src/context/ThemeContext.tsx
-import { ReactNode, useEffect } from 'react'
+// Wraps next-themes to expose color-scheme selection driven by tokens.
+'use client'
+import { ReactNode } from 'react'
+import {
+  ThemeProvider as NextThemesProvider,
+  useTheme as useNextTheme,
+} from 'next-themes'
 
-// Single theme applied across the app to avoid a route-based rainbow
-const THEME_VARS: Record<string, string> = {
-  '--theme-background': '#f0f4ff',
-  '--theme-primary':    '#1e40af',
-  '--theme-accent':     '#3b82f6',
-}
-
-export function deriveThemeId(_: string) {
-  return 'default'
-}
+export const AVAILABLE_SCHEMES = ['light', 'dark', 'sepia', 'royal'] as const
+export type ColorScheme = (typeof AVAILABLE_SCHEMES)[number]
 
 export function ThemeProvider({ children }: { children: ReactNode }) {
-  useEffect(() => {
-    Object.entries(THEME_VARS).forEach(([k, v]) =>
-      document.documentElement.style.setProperty(k, v)
-    )
-  }, [])
+  return (
+    <NextThemesProvider
+      attribute="data-theme"
+      defaultTheme="light"
+      enableSystem={false}
+    >
+      {children}
+    </NextThemesProvider>
+  )
+}
 
-  return <>{children}</>
+export function useTheme() {
+  const { theme, setTheme } = useNextTheme()
+  return { scheme: (theme as ColorScheme) || 'light', setScheme: setTheme }
+}
+
+export function deriveThemeId(_: string): ColorScheme {
+  return 'light'
 }
 

--- a/docker/web-app/src/context/__tests__/ThemeContext.test.tsx
+++ b/docker/web-app/src/context/__tests__/ThemeContext.test.tsx
@@ -2,7 +2,7 @@ import test from 'node:test'
 import assert from 'node:assert'
 import { deriveThemeId } from '../ThemeContext'
 
-test('deriveThemeId returns default for any path', () => {
-  assert.strictEqual(deriveThemeId('/tenant/dam-explorer'), 'default')
-  assert.strictEqual(deriveThemeId('/tenant/unknown'), 'default')
+test('deriveThemeId returns light for any path', () => {
+  assert.strictEqual(deriveThemeId('/tenant/dam-explorer'), 'light')
+  assert.strictEqual(deriveThemeId('/tenant/unknown'), 'light')
 })

--- a/docker/web-app/src/hooks/useTheme.ts
+++ b/docker/web-app/src/hooks/useTheme.ts
@@ -1,8 +1,0 @@
-// hooks/useTheme.ts
-import { useEffect } from 'react'
-
-export default function useTheme(name: 'light'|'dark') {
-  useEffect(() => {
-    document.documentElement.setAttribute('data-theme', name)
-  }, [name])
-}

--- a/docker/web-app/src/lib/__tests__/tokens.test.ts
+++ b/docker/web-app/src/lib/__tests__/tokens.test.ts
@@ -15,5 +15,8 @@ test('tokens.css exposes required color variables', () => {
   const css = readFileSync(TOKENS_PATH, 'utf8');
   assert.match(css, /--color-primary-500:/);
   assert.match(css, /--color-success-500:/);
+  assert.match(css, /\[data-theme='dark'\]/);
+  assert.match(css, /\[data-theme='sepia'\]/);
+  assert.match(css, /\[data-theme='royal'\]/);
 });
 

--- a/docker/web-app/src/styles/README.md
+++ b/docker/web-app/src/styles/README.md
@@ -60,6 +60,12 @@ A default blue theme applies across the app via three CSS variables:
 
 Changing these values updates the global background and accent colors without touching component markup.
 
+### Color Schemes
+
+`ThemeProvider` wraps [`next-themes`](https://github.com/pacocoursey/next-themes) and applies a `data-theme` attribute on the
+root element. Predefined schemes (`light`, `dark`, `sepia`, `royal`) are driven by the variables in `tokens.css`, and the top bar
+dropdown lets users switch schemes at runtime.
+
 ## Color Tokens
 
 Color tokens allow components to stay theme-aware without hardcoding Tailwind palette values.

--- a/docker/web-app/src/styles/tokens.css
+++ b/docker/web-app/src/styles/tokens.css
@@ -164,3 +164,71 @@
   --shadow-md: 0 4px 6px rgba(0,0,0,0.1);
   --shadow-lg: 0 10px 15px rgba(0,0,0,0.15);
 }
+
+[data-theme='dark'] {
+  --color-background   : var(--color-neutral-900);
+  --color-surface      : var(--color-neutral-800);
+  --color-surface-alt  : var(--color-neutral-700);
+  --color-border       : var(--color-neutral-600);
+  --color-text         : var(--color-neutral-100);
+  --color-muted        : var(--color-neutral-400);
+  --color-primary      : var(--color-primary-400);
+  --color-primary-bg   : var(--color-primary-900);
+  --color-accent       : var(--color-accent-400);
+  --color-accent-bg    : var(--color-accent-900);
+  --color-success      : var(--color-success-400);
+  --color-success-bg   : var(--color-success-900);
+  --color-warning      : var(--color-warning-400);
+  --color-warning-bg   : var(--color-warning-900);
+  --color-error        : var(--color-error-400);
+  --color-error-bg     : var(--color-error-900);
+  --theme-background   : #0f172a;
+  --theme-primary      : #3b82f6;
+  --theme-accent       : #a855f7;
+}
+
+/* Sepia theme */
+[data-theme='sepia'] {
+  --color-background   : var(--color-warning-50);
+  --color-surface      : var(--color-warning-100);
+  --color-surface-alt  : var(--color-warning-200);
+  --color-border       : var(--color-warning-300);
+  --color-text         : var(--color-warning-900);
+  --color-muted        : var(--color-warning-600);
+  --color-primary      : var(--color-warning-700);
+  --color-primary-bg   : var(--color-warning-50);
+  --color-accent       : var(--color-accent-600);
+  --color-accent-bg    : var(--color-accent-50);
+  --color-success      : var(--color-success-700);
+  --color-success-bg   : var(--color-success-50);
+  --color-warning      : var(--color-warning-700);
+  --color-warning-bg   : var(--color-warning-50);
+  --color-error        : var(--color-error-600);
+  --color-error-bg     : var(--color-error-50);
+  --theme-background   : #fdf6e3;
+  --theme-primary      : #b45309;
+  --theme-accent       : #7e22ce;
+}
+
+/* Royal theme */
+[data-theme='royal'] {
+  --color-background   : var(--color-accent-50);
+  --color-surface      : var(--color-accent-100);
+  --color-surface-alt  : var(--color-accent-200);
+  --color-border       : var(--color-accent-300);
+  --color-text         : var(--color-accent-900);
+  --color-muted        : var(--color-accent-600);
+  --color-primary      : var(--color-accent-700);
+  --color-primary-bg   : var(--color-accent-50);
+  --color-accent       : var(--color-warning-600);
+  --color-accent-bg    : var(--color-warning-50);
+  --color-success      : var(--color-success-700);
+  --color-success-bg   : var(--color-success-50);
+  --color-warning      : var(--color-warning-700);
+  --color-warning-bg   : var(--color-warning-50);
+  --color-error        : var(--color-error-600);
+  --color-error-bg     : var(--color-error-50);
+  --theme-background   : #f5f3ff;
+  --theme-primary      : #7e22ce;
+  --theme-accent       : #b45309;
+}

--- a/docker/web-app/tsconfig.test.json
+++ b/docker/web-app/tsconfig.test.json
@@ -36,7 +36,6 @@
   "exclude": [
     "src/components/CameraMonitor/**",
     "src/components/__tests__/CameraMonitor.test.ts",
-    "src/components/__tests__/TopBar.test.tsx",
     "src/components/modals/**",
     "src/components/overlays/**"
   ]


### PR DESCRIPTION
Milestone: 🧬 Feature Development
Scope: docker/web-app
Linked Issues: 

## Summary
- use next-themes to manage token-driven color schemes
- add sepia and royal options and update tokens, tests, and docs
- restore test config includes for full suite coverage

## Testing
- `npm test` *(fails: Cannot find modules for LayeredExplorer and next-themes)*
- `npm run lint` *(prompts for ESLint configuration)*

## Checklist
- [x] Code is self-contained and idempotent.
- [x] No unnecessary new files or external dependencies.
- [x] Tests added or updated as appropriate.
- [x] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_68a76fbe200883269556ac881ee8473c