### PR TITLE
docs: expand wireless hdmi transmitter architecture

### DIFF
--- a/docs/TECHNICAL/wireless-hdmi/transmitter-architecture.md
+++ b/docs/TECHNICAL/wireless-hdmi/transmitter-architecture.md
@@ -1,0 +1,78 @@
+# Wireless HDMI Transmitter Architecture
+
+The Wi-Fi HDMI transmitter stitches together existing services:
+
+- [camera-proxy](../../../host/services/camera-proxy/README.md)
+- [capture-daemon](../../../host/services/capture-daemon/README.md)
+- [api-gateway](../../../host/services/api-gateway/README.md)
+- [overlay-hub](../../../host/services/overlay-hub/README.md)
+- [Hardware Capture Module](../../../video/modules/hwcapture/README.md)
+
+## Timestamp discipline
+Capture nodes stamp frames with a monotonic clock synchronised via gPTP. The
+[timestamping helper](../../../video/modules/hwcapture/README.md) exposes the
+capture clock so `camera-proxy` and `capture-daemon` can align audio and video.
+All services accept a `TIME_SOURCE` override so a Precision Time Protocol grandmaster
+can steer clocks across the network.
+
+## Encoder matrix
+| Device class | Encoder | Max resolution | Notes |
+|--------------|---------|----------------|-------|
+| Raspberry Pi 4 | MMAL H.264 | 1080p60 | Baseline profile, IDR every 0.5 s |
+| x86 w/ VAAPI | VAAPI H.264/H.265 | 4K30 | Uses `FFMPEG_HWACCEL` hints |
+| Nvidia Jetson | NVENC H.264/H.265 | 4K60 | Low‑delay preset, CBR |
+
+## Transport descriptors
+`camera-proxy` publishes several transports:
+
+- **WebRTC** – browser‑friendly, SRTP over UDP with ICE negotiation.
+- **SRT** – ARQ/FEC over UDP for dedicated apps.
+- **LL-HLS** – chunked CMAF fallback when UDP paths fail.
+- **NDI‑HX** – optional LAN mode for editor tooling.
+
+## Registry schema
+Streams register through the [api-gateway](../../../host/services/api-gateway/README.md)
+and are advertised by the overlay registry:
+
+```json
+{
+  "id": "cam1",
+  "owner": "nodeA",
+  "transports": ["webrtc", "srt"],
+  "qos": "hd-60",
+  "overlay": "hub1"
+}
+```
+
+## QoS profiles
+| Profile | Target | ABR ladder (Mbps) | Keyframe interval |
+|---------|--------|-------------------|-------------------|
+| `hd-60` | 1080p60 | 12, 8, 6 | 0.5 s |
+| `hd-30` | 1080p30 | 8, 6, 4 | 1 s |
+| `sd-30` | 720p30  | 4, 3, 2 | 1 s |
+
+## TSN hooks
+Time‑Sensitive Networking is optional. When `TSN_ENABLED=1`, `camera-proxy`
+marks packets with 802.1Qav priorities and consults `overlay-hub` for
+802.1AS clock state. Nodes without TSN support ignore these hints.
+
+## Overlay‑hub decision logic
+The [overlay-hub](../../../host/services/overlay-hub/README.md) scores each
+registering agent using round‑trip time and offered bitrate. Agents exceeding
+`150ms` RTT or lacking capacity are instructed to relay through a nearby peer;
+otherwise they negotiate direct sessions.
+
+## Telemetry‑based fallback criteria
+`camera-proxy` reports packet loss and jitter to the hub every heartbeat. If
+loss exceeds `5%` over three intervals or RTT rises above `200ms`, the hub
+notifies clients to drop to SRT; continued degradation triggers LL‑HLS.
+
+## Test methodology
+1. Start services via compose and register a camera.
+2. Measure glass‑to‑glass latency using a LED timer in frame.
+3. Record packet loss and jitter from overlay telemetry.
+4. Assert profile bitrates with `ffprobe` and check fallback triggers by
+simulating loss with `tc netem`.
+
+Automate these steps under `tests/wireless_hdmi/` to keep the pipeline
+regression‑free.

--- a/host/services/api-gateway/README.md
+++ b/host/services/api-gateway/README.md
@@ -28,3 +28,10 @@ Configure via environment variables:
 - `POST /agents/issue`
 - `GET /.well-known/jwks.json`
 - `GET /overlay/hints`
+
+### See also
+- [camera-proxy](../camera-proxy/README.md)
+- [capture-daemon](../capture-daemon/README.md)
+- [overlay-hub](../overlay-hub/README.md)
+- [Hardware Capture Module](../../../video/modules/hwcapture/README.md)
+- [Wireless HDMI Transmitter Architecture](../../../docs/TECHNICAL/wireless-hdmi/transmitter-architecture.md)

--- a/host/services/camera-proxy/README.md
+++ b/host/services/camera-proxy/README.md
@@ -95,3 +95,10 @@ curl -i 'http://localhost:8000/stream?device=daemon:cam1'
 
 If WebRTC negotiation with the daemon fails, the proxy serves an MJPEG stream directly so browsers and tools can still view the feed.
 
+
+### See also
+- [capture-daemon](../capture-daemon/README.md)
+- [api-gateway](../api-gateway/README.md)
+- [overlay-hub](../overlay-hub/README.md)
+- [Hardware Capture Module](../../../video/modules/hwcapture/README.md)
+- [Wireless HDMI Transmitter Architecture](../../../docs/TECHNICAL/wireless-hdmi/transmitter-architecture.md)

--- a/host/services/capture-daemon/README.md
+++ b/host/services/capture-daemon/README.md
@@ -91,3 +91,10 @@ Set these variables to control log output:
 
 Set `AUTH_TOKEN` to require a bearer token on API requests. To serve HTTPS, provide `TLS_CERT_FILE` and `TLS_KEY_FILE` with the certificate and key paths.
 
+
+### See also
+- [camera-proxy](../camera-proxy/README.md)
+- [api-gateway](../api-gateway/README.md)
+- [overlay-hub](../overlay-hub/README.md)
+- [Hardware Capture Module](../../../video/modules/hwcapture/README.md)
+- [Wireless HDMI Transmitter Architecture](../../../docs/TECHNICAL/wireless-hdmi/transmitter-architecture.md)

--- a/host/services/overlay-hub/README.md
+++ b/host/services/overlay-hub/README.md
@@ -14,3 +14,10 @@ Endpoints:
 - `POST /v1/register`
 - `POST /v1/heartbeat`
 - `POST /v1/negotiate`
+
+### See also
+- [camera-proxy](../camera-proxy/README.md)
+- [capture-daemon](../capture-daemon/README.md)
+- [api-gateway](../api-gateway/README.md)
+- [Hardware Capture Module](../../../video/modules/hwcapture/README.md)
+- [Wireless HDMI Transmitter Architecture](../../../docs/TECHNICAL/wireless-hdmi/transmitter-architecture.md)

--- a/video/modules/hwcapture/README.md
+++ b/video/modules/hwcapture/README.md
@@ -52,3 +52,10 @@ python -m video witness_record --duration 10
 
 Writes `main_raw.mp4` and a stabilised witness copy.
 
+
+### See also
+- [camera-proxy](../../../host/services/camera-proxy/README.md)
+- [capture-daemon](../../../host/services/capture-daemon/README.md)
+- [api-gateway](../../../host/services/api-gateway/README.md)
+- [overlay-hub](../../../host/services/overlay-hub/README.md)
+- [Wireless HDMI Transmitter Architecture](../../../docs/TECHNICAL/wireless-hdmi/transmitter-architecture.md)


### PR DESCRIPTION
Milestone: 🧬 Feature Development
Scope: docs,camera-proxy,capture-daemon,api-gateway,overlay-hub,hwcapture
Linked Issues: N/A

## Summary
- document wireless HDMI transmitter pipeline with timestamp discipline, encoder matrix, registry schema, QoS profiles, TSN hooks, decision logic, telemetry fallback, and test methodology
- cross-link service READMEs for camera-proxy, capture-daemon, api-gateway, overlay-hub, and hwcapture

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'video')*
- `(cd host/services/camera-proxy && go test ./...)`
- `(cd host/services/capture-daemon && go test ./...)`
- `(cd host/services/api-gateway && go test ./...)`
- `(cd host/services/overlay-hub && go test ./...)`

## Checklist
- [x] Code is self-contained and idempotent.
- [x] No unnecessary new files or external dependencies.
- [x] Tests added or updated as appropriate.
- [x] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_68a793e3e3808326bc24b37e951be142