### PR TITLE
feat: add trim idle dashboard plugin and factory

### DIFF
--- a/docker/web-app/src/app/[tenant]/dashboard/README.md
+++ b/docker/web-app/src/app/[tenant]/dashboard/README.md
@@ -11,4 +11,5 @@ Tools are rendered in primary/secondary/tertiary sections based on activity and 
 | /{tenant}/dashboard/motion               | Motion Tool        |
 | /{tenant}/dashboard/live                 | Live Monitor       |
 | /{tenant}/dashboard/witness              | Witness Tool       |
+| /{tenant}/dashboard/trim-idle            | Trim Idle          |
 

--- a/docker/web-app/src/app/[tenant]/dashboard/trim-idle/page.tsx
+++ b/docker/web-app/src/app/[tenant]/dashboard/trim-idle/page.tsx
@@ -1,0 +1,5 @@
+import TrimIdle from '@/components/tools/TrimIdle'
+
+export default function TrimIdlePage() {
+  return <TrimIdle />
+}

--- a/docker/web-app/src/components/__tests__/UploadPicker.test.tsx
+++ b/docker/web-app/src/components/__tests__/UploadPicker.test.tsx
@@ -1,0 +1,14 @@
+import assert from 'node:assert'
+import test from 'node:test'
+import React from 'react'
+import { renderToString } from 'react-dom/server'
+import UploadPicker from '../primitives/UploadPicker'
+
+test('UploadPicker renders options', () => {
+  const html = renderToString(
+    <UploadPicker onSelectFile={() => {}} onSelectDam={() => {}} onSelectCamera={() => {}} />
+  )
+  assert.ok(html.includes('Upload'))
+  assert.ok(html.includes('Files'))
+  assert.ok(html.includes('Camera'))
+})

--- a/docker/web-app/src/components/__tests__/dashboardTools.trim-idle.test.tsx
+++ b/docker/web-app/src/components/__tests__/dashboardTools.trim-idle.test.tsx
@@ -1,0 +1,9 @@
+import assert from 'node:assert';
+import test from 'node:test';
+import { dashboardTools } from '../dashboardTools';
+
+test('includes trim-idle tool with correct href', () => {
+  const tool = dashboardTools['trim-idle'];
+  assert.ok(tool, 'trim-idle tool missing');
+  assert.equal(tool.href, '/dashboard/trim-idle');
+});

--- a/docker/web-app/src/components/dashboardTools.tsx
+++ b/docker/web-app/src/components/dashboardTools.tsx
@@ -1,37 +1,10 @@
 import { dashboardColorClasses } from '../styles/theme';
-import { Camera, FolderOpen, Video, Activity, UserCheck, Eye, Server } from 'lucide-react';
+import { Camera, FolderOpen, Video, Activity, UserCheck, Eye, Server, Scissors } from 'lucide-react';
+import { createTool, registerTool, getTools, DashboardTool } from '../lib/toolRegistry';
 
-/** 
- * A dashboard "tool" with rich metadata for intelligent layout 
- */
-export interface DashboardTool {
-  id: string;
-  href: string;
-  title: string;
-  icon: React.ComponentType<any>;
-  color: string;
-  context: string;
-  relatedTools: string[];
-  lastUsed: string; // ISO timestamp
-  status: 'active' | 'processing' | 'idle';
-}
-
-/** 
- * Your canonical list of dashboard tools, now with context, recency, status, etc. 
- */
-export const dashboardTools: Record<string, DashboardTool> = {
-  nodes: {
-    id: 'nodes',
-    href: '/dashboard/nodes',
-    title: 'Nodes',
-    icon: Server,
-    color: dashboardColorClasses['nodes'],
-    context: 'cluster',
-    relatedTools: [],
-    lastUsed: new Date().toISOString(),
-    status: 'idle',
-  },
-  'camera-monitor': {
+const tools: Parameters<typeof createTool>[0][] = [
+  { id: 'nodes', href: '/dashboard/nodes', title: 'Nodes', icon: Server, color: dashboardColorClasses['nodes'], context: 'cluster', relatedTools: [] },
+  {
     id: 'camera-monitor',
     href: '/dashboard/camera-monitor',
     title: 'Camera Monitor',
@@ -42,7 +15,7 @@ export const dashboardTools: Record<string, DashboardTool> = {
     lastUsed: '2024-01-20T10:30:00Z',
     status: 'active',
   },
-  'dam-explorer': {
+  {
     id: 'dam-explorer',
     href: '/dashboard/dam-explorer',
     title: 'DAM Explorer',
@@ -51,9 +24,8 @@ export const dashboardTools: Record<string, DashboardTool> = {
     context: 'archive',
     relatedTools: ['camera-monitor', 'motion'],
     lastUsed: '2024-01-20T09:15:00Z',
-    status: 'idle',
   },
-  motion: {
+  {
     id: 'motion',
     href: '/dashboard/motion',
     title: 'Motion Tool',
@@ -62,9 +34,8 @@ export const dashboardTools: Record<string, DashboardTool> = {
     context: 'analysis',
     relatedTools: ['dam-explorer', 'witness'],
     lastUsed: '2024-01-19T16:20:00Z',
-    status: 'idle',
   },
-  live: {
+  {
     id: 'live',
     href: '/dashboard/live',
     title: 'Live Monitor',
@@ -75,7 +46,7 @@ export const dashboardTools: Record<string, DashboardTool> = {
     lastUsed: '2024-01-20T08:45:00Z',
     status: 'processing',
   },
-  witness: {
+  {
     id: 'witness',
     href: '/dashboard/witness',
     title: 'Witness Tool',
@@ -84,9 +55,8 @@ export const dashboardTools: Record<string, DashboardTool> = {
     context: 'security',
     relatedTools: ['motion', 'live'],
     lastUsed: '2024-01-18T14:30:00Z',
-    status: 'idle',
   },
-  ffmpeg: {
+  {
     id: 'ffmpeg',
     href: '/dashboard/ffmpeg',
     title: 'FFmpeg Console',
@@ -95,6 +65,19 @@ export const dashboardTools: Record<string, DashboardTool> = {
     context: 'analysis',
     relatedTools: ['motion'],
     lastUsed: '2024-01-16T12:00:00Z',
-    status: 'idle',
   },
-};
+  {
+    id: 'trim-idle',
+    href: '/dashboard/trim-idle',
+    title: 'Trim Idle',
+    icon: Scissors,
+    color: dashboardColorClasses['trim-idle'],
+    context: 'analysis',
+    relatedTools: ['dam-explorer'],
+  },
+];
+
+tools.forEach(tool => registerTool(createTool(tool)));
+
+export type { DashboardTool };
+export const dashboardTools: Record<string, DashboardTool> = getTools();

--- a/docker/web-app/src/components/primitives/UploadPicker.tsx
+++ b/docker/web-app/src/components/primitives/UploadPicker.tsx
@@ -1,0 +1,60 @@
+import { useRef } from 'react'
+
+/**
+ * Allows selecting a video from local device, DAM files, or camera.
+ *
+ * Example:
+ * ```tsx
+ * <UploadPicker
+ *   onSelectFile={setFile}
+ *   onSelectDam={() => router.push('/dashboard/dam-explorer')}
+ *   onSelectCamera={() => router.push('/dashboard/camera-monitor')}
+ * />
+ * ```
+ */
+export default function UploadPicker({
+  onSelectFile,
+  onSelectDam,
+  onSelectCamera,
+}: {
+  onSelectFile: (file: File) => void
+  onSelectDam?: () => void
+  onSelectCamera?: () => void
+}) {
+  const inputRef = useRef<HTMLInputElement>(null)
+  return (
+    <div className="flex gap-2">
+      <button
+        type="button"
+        className="px-4 py-2 bg-blue-600 text-white rounded"
+        onClick={() => inputRef.current?.click()}
+      >
+        Upload
+      </button>
+      <button
+        type="button"
+        className="px-4 py-2 bg-gray-200 rounded"
+        onClick={onSelectDam}
+      >
+        Files
+      </button>
+      <button
+        type="button"
+        className="px-4 py-2 bg-gray-200 rounded"
+        onClick={onSelectCamera}
+      >
+        Camera
+      </button>
+      <input
+        ref={inputRef}
+        type="file"
+        accept="video/*"
+        className="hidden"
+        onChange={e => {
+          const file = e.target.files?.[0]
+          if (file) onSelectFile(file)
+        }}
+      />
+    </div>
+  )
+}

--- a/docker/web-app/src/components/tools/TrimIdle.tsx
+++ b/docker/web-app/src/components/tools/TrimIdle.tsx
@@ -1,0 +1,61 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { videoApi } from '../../lib/videoApi'
+import UploadPicker from '../primitives/UploadPicker'
+import { createToolPage } from '../../lib/toolRegistry'
+
+/**
+ * UI for the trim_idle video-api module.
+ * Allows uploading a video and downloads the trimmed result.
+ */
+function TrimIdleContent() {
+  const [file, setFile] = useState<File | null>(null)
+  const [status, setStatus] = useState<'idle' | 'working' | 'error' | 'done'>('idle')
+  const [downloadUrl, setDownloadUrl] = useState<string | null>(null)
+  const router = useRouter()
+
+  async function handleSubmit() {
+    if (!file) return
+    setStatus('working')
+    try {
+      const blob = await videoApi.trimIdle({ file })
+      setDownloadUrl(URL.createObjectURL(blob))
+      setStatus('done')
+    } catch (err) {
+      setStatus('error')
+    }
+  }
+
+  return (
+    <>
+      <UploadPicker
+        onSelectFile={setFile}
+        onSelectDam={() => router.push('/dashboard/dam-explorer')}
+        onSelectCamera={() => router.push('/dashboard/camera-monitor')}
+      />
+      <button
+        className="px-4 py-2 bg-blue-600 text-white rounded disabled:opacity-50"
+        onClick={handleSubmit}
+        disabled={!file || status === 'working'}
+      >
+        Trim
+      </button>
+      {status === 'error' && (
+        <p className="text-sm text-red-600">Failed to trim video</p>
+      )}
+      {downloadUrl && (
+        <a
+          className="text-sm text-blue-600 underline"
+          href={downloadUrl}
+          download="trimmed.mp4"
+        >
+          Download trimmed video
+        </a>
+      )}
+    </>
+  )
+}
+
+export default createToolPage('Trim Idle', TrimIdleContent)

--- a/docker/web-app/src/hooks/__tests__/useIntelligentLayout.test.tsx
+++ b/docker/web-app/src/hooks/__tests__/useIntelligentLayout.test.tsx
@@ -3,7 +3,7 @@ import test from 'node:test'
 import React from 'react'
 import { renderToString } from 'react-dom/server'
 import { computeLayoutGroups, useIntelligentLayout } from '../useIntelligentLayout'
-import type { DashboardTool } from '@/components/dashboardTools'
+import type { DashboardTool } from '../../lib/toolRegistry'
 import { dashboardTools } from '../../components/dashboardTools'
 
 const sample: DashboardTool[] = [

--- a/docker/web-app/src/hooks/useIntelligentLayout.ts
+++ b/docker/web-app/src/hooks/useIntelligentLayout.ts
@@ -1,5 +1,5 @@
 import { useState, useMemo } from 'react'
-import type { DashboardTool } from '../components/dashboardTools'
+import type { DashboardTool } from '../lib/toolRegistry'
 
 /** Compute groups of tools based on status and recency */
 export function computeLayoutGroups(tools: DashboardTool[]) {

--- a/docker/web-app/src/lib/toolRegistry.tsx
+++ b/docker/web-app/src/lib/toolRegistry.tsx
@@ -1,0 +1,64 @@
+import type { ComponentType } from 'react';
+
+/**
+ * Canonical dashboard tool definition.
+ * Used to render cards and resolve dynamic tool pages.
+ */
+export interface DashboardTool {
+  id: string;
+  href: string;
+  title: string;
+  icon: ComponentType<any>;
+  color: string;
+  context: string;
+  relatedTools: string[];
+  lastUsed: string; // ISO timestamp
+  status: 'active' | 'processing' | 'idle';
+}
+
+const registry: Record<string, DashboardTool> = {};
+
+/**
+ * Create a DashboardTool with sensible defaults.
+ */
+export function createTool(
+  config: Omit<DashboardTool, 'lastUsed' | 'status' | 'relatedTools' | 'context' | 'color'> &
+    Partial<Pick<DashboardTool, 'lastUsed' | 'status' | 'relatedTools' | 'context' | 'color'>>
+): DashboardTool {
+  return {
+    color: config.color ?? '',
+    context: config.context ?? 'misc',
+    relatedTools: config.relatedTools ?? [],
+    lastUsed: config.lastUsed ?? new Date().toISOString(),
+    status: config.status ?? 'idle',
+    ...config,
+  };
+}
+
+/**
+ * Register a tool in the global dashboard registry.
+ */
+export function registerTool(tool: DashboardTool) {
+  registry[tool.id] = tool;
+}
+
+/**
+ * Retrieve the current tool registry.
+ */
+export function getTools() {
+  return registry;
+}
+
+/**
+ * Factory to wrap tool page content with common layout elements.
+ */
+export function createToolPage(title: string, Content: ComponentType<any>): ComponentType<any> {
+  return function ToolPage(props: any) {
+    return (
+      <section className="p-6 space-y-4">
+        <h2 className="text-xl font-bold">{title}</h2>
+        <Content {...props} />
+      </section>
+    );
+  };
+}

--- a/docker/web-app/src/styles/theme.ts
+++ b/docker/web-app/src/styles/theme.ts
@@ -90,4 +90,5 @@ export const dashboardColorClasses: Record<string, string> = {
   live:             'text-[var(--color-live)]',
   witness:          'text-[var(--color-witness)]',
   nodes:            'text-[var(--color-nodes)]',
+  'trim-idle':      'text-[var(--color-trim-idle)]',
 };


### PR DESCRIPTION
Milestone: 🧬 Feature Development
Scope: web-app
Linked Issues: 

## Summary
- add toolRegistry factory for dashboard plugin registration
- integrate Trim Idle tool and page using registry and UploadPicker
- expose trimIdle API method and color token

## Testing
- `npm test` *(fails: missing three.js and related declarations)*

## Checklist
- [ ] Code is self-contained and idempotent.
- [ ] No unnecessary new files or external dependencies.
- [ ] Tests added or updated as appropriate.
- [ ] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_68a7962d14d48326a470dacdb6618dd4