### PR TITLE
fix: drop legacy dashboard override from nginx gateway

### DIFF
--- a/docker/nginx/README.md
+++ b/docker/nginx/README.md
@@ -30,7 +30,10 @@ docker/nginx/
 
 ## 1 ↦ nginx.tmpl
 
-The main configuration template that gets rendered with environment variables:
+The main configuration template that gets rendered with environment variables.
+The legacy `ServiceDashboard.html` override has been removed so the gateway
+always proxies to the live Next.js frontend, preserving the original `Host`
+header for tenancy-aware routing.
 
 ```nginx
 # Nginx front door for That DAM Toolbox

--- a/docker/nginx/nginx.tmpl
+++ b/docker/nginx/nginx.tmpl
@@ -81,17 +81,6 @@ http {
         #     proxy_pass http://video_web;
         # }
 
-        # ------------------ Dev frontend (Next.js) ------------------------
-        # In local dev we don’t have a static build yet--just proxy everything
-        # ------------------ Dashboard (exact match; bypass Next.js) --------
-        # Put the file at docker/web-app/out/ServiceDashboard.html
-        # (mounted to /usr/share/nginx/html via compose)
-        location = /ServiceDashboard.html {
-            root /usr/share/nginx/html;
-            default_type text/html;
-            expires -1;   # disable cache while iterating
-        }
-
         # ------------------ PREVIEW PROXY (same-origin iframes) ------------
         # Each block strips upstream frame-blockers and allows SAMEORIGIN.
 
@@ -208,7 +197,8 @@ http {
         }
 
         # ------------------ Dev frontend (Next.js) --------------------------
-        # In local dev we don’t have a static build yet--just proxy everything.
+        # In local dev we don’t have a static build yet—proxy everything to the
+        # live Next.js server so theme changes appear immediately.
         location / {
             include proxy_defaults.conf;
             proxy_pass http://video_web;

--- a/tests/test_nginx_entrypoint_snippets.py
+++ b/tests/test_nginx_entrypoint_snippets.py
@@ -101,3 +101,12 @@ def test_upstream_resolution(tmp_path: Path) -> None:
     assert bad.returncode != 0
     assert "unable to resolve upstream host 'no-such-host'" in bad.stderr
 
+
+def test_template_proxies_root() -> None:
+    """The nginx template should proxy root requests to the live web app."""
+
+    tmpl = Path("docker/nginx/nginx.tmpl").read_text()
+    assert "ServiceDashboard.html" not in tmpl
+    assert "proxy_pass http://video_web" in tmpl
+    assert "proxy_set_header Host $host;" in tmpl
+


### PR DESCRIPTION
Milestone: 🧬 Feature Development
Scope: docker/nginx, tests
Linked Issues: N/A

## Summary
- remove stale ServiceDashboard.html override from nginx template and forward root requests to live Next.js app
- document host header preservation for tenancy-aware routing
- test nginx template omits ServiceDashboard override, proxies to video_web, and forwards host header

## Testing
- `pytest tests/test_nginx_entrypoint_snippets.py::test_template_proxies_root -q` *(fails: ModuleNotFoundError: No module named 'video')*

## Checklist
- [ ] Code is self-contained and idempotent.
- [ ] No unnecessary new files or external dependencies.
- [ ] Tests added or updated as appropriate.
- [ ] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_68a7af94cc888326b24217c186a61206