### PR TITLE
fix: export dashboard tools map for sidebar

### DIFF
--- a/docker/web-app/src/components/dashboardTools.tsx
+++ b/docker/web-app/src/components/dashboardTools.tsx
@@ -9,7 +9,7 @@ import {
   Server,
   Scissors,
 } from 'lucide-react';
-import { createTool, registerTool, getTools, DashboardTool } from '../lib/toolRegistry';
+import { createTool, registerTool, DashboardTool } from '../lib/toolRegistry';
 
 /**
  * Merged, de-conflicted tool catalog.
@@ -82,11 +82,11 @@ const tools: Parameters<typeof createTool>[0][] = [
     status: 'idle',
   },
   {
-    id: 'trim',
-    href: '/dashboard/trim',
+    id: 'trim-idle',
+    href: '/dashboard/trim-idle',
     title: 'Trim / Idle Module',
     icon: Scissors,
-    color: dashboardColorClasses['trim'],
+    color: dashboardColorClasses['trim-idle'],
     context: 'post',
     relatedTools: ['dam-explorer', 'motion'],
     status: 'idle',
@@ -103,10 +103,15 @@ const tools: Parameters<typeof createTool>[0][] = [
   },
 ];
 
+const dashboardTools: Record<string, DashboardTool> = {};
+tools.forEach((cfg) => {
+  dashboardTools[cfg.id] = createTool(cfg);
+});
+
 // Optional: register on import; or call initDashboardTools() from your app bootstrap.
 export function initDashboardTools() {
-  tools.forEach((t) => registerTool(t));
+  Object.values(dashboardTools).forEach(registerTool);
 }
 
-export { tools };
+export { tools, dashboardTools };
 export type { DashboardTool };


### PR DESCRIPTION
Milestone: 🧬 Feature Development
Scope: web-app
Linked Issues: none

## Summary
- export dashboard tools map with trim-idle entry to resolve sidebar failures

## Testing
- `NODE_PATH=node_modules node --test /tmp/webapp-tests/components/__tests__/dashboardTools.nodes.test.js /tmp/webapp-tests/components/__tests__/dashboardTools.trim-idle.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a7bddabb408326aad27d324ec50982