### PR TITLE
fix: reconcile postgres collation on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,4 @@
 
 ## Unreleased
 - archive POC services (proxy, schema-registry, poc_video-pipeline-manager) and driver (virtual-video-pipeline.cpp) under host/legacy
+- reconcile Postgres collation version on startup to silence glibc mismatch warnings

--- a/docker/compose/docker-compose.postgres.yaml
+++ b/docker/compose/docker-compose.postgres.yaml
@@ -22,3 +22,15 @@ services:
       start_period: 10s
     restart: unless-stopped
     networks: [damnet]
+
+  # One-off job to reconcile collation versions after glibc upgrades
+  postgres-collation-refresh:
+    image: postgres:15
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      PGPASSWORD: weaviate
+    command: ["psql","-v","ON_ERROR_STOP=1","-h","postgres","-U","weaviate","-d","weaviate","-c","ALTER DATABASE weaviate REFRESH COLLATION VERSION;"]
+    restart: "no"
+    networks: [damnet]

--- a/script_tests/test_postgres_collation_refresh.py
+++ b/script_tests/test_postgres_collation_refresh.py
@@ -1,0 +1,14 @@
+"""Ensure PostgreSQL collation refresh job is present.
+
+Example:
+    pytest script_tests/test_postgres_collation_refresh.py -q
+"""
+from pathlib import Path
+import yaml
+
+def test_collation_refresh_service_present():
+    compose = yaml.safe_load(Path("docker/compose/docker-compose.postgres.yaml").read_text())
+    services = compose.get("services", {})
+    assert "postgres-collation-refresh" in services, "collation refresh service missing"
+    cmd = services["postgres-collation-refresh"].get("command", [])
+    assert "ALTER DATABASE weaviate REFRESH COLLATION VERSION;" in cmd


### PR DESCRIPTION
Milestone: 🧬 Feature Development
Scope: docker, tests
Linked Issues: none

## Summary
- refresh Postgres collation on container startup to handle glibc upgrades
- add regression test for collation refresh job
- document collation fix in changelog

## Testing
- `pytest script_tests/test_postgres_collation_refresh.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'video')*

------
https://chatgpt.com/codex/tasks/task_e_68a7cc3ee3ac8326b58aeaaedbc5c847