### PR TITLE
feat: add task stubs for monitor and explorer spec

### DIFF
--- a/docker/web-app/src/components/__tests__/uiUxTasks.test.ts
+++ b/docker/web-app/src/components/__tests__/uiUxTasks.test.ts
@@ -1,0 +1,17 @@
+/**
+ * Ensures every UI/UX task stub exists and throws "Not implemented".
+ *
+ * Run with: npm test
+ */
+import test from 'node:test'
+import assert from 'node:assert'
+import { uiUxTasks, taskNames } from '../uiUxTasks'
+
+test('UI/UX task stubs throw not implemented', () => {
+  for (const name of taskNames) {
+    const fn = uiUxTasks[name]
+    assert.strictEqual(typeof fn, 'function', `${name} should be a function`)
+    assert.throws(() => fn(), /Not implemented/)
+  }
+})
+

--- a/docker/web-app/src/components/uiUxTasks.ts
+++ b/docker/web-app/src/components/uiUxTasks.ts
@@ -1,0 +1,141 @@
+/**
+ * Task stubs for the Camera Monitor and Explorer mobile-first specification.
+ * Each function represents an implementation task from
+ * docs/TECHNICAL/CAMERA_MONITOR_EXPLORER_SPEC.md.
+ *
+ * Usage: import individual functions or iterate over `uiUxTasks` to
+ * drive future implementation work. Tasks are grouped into global,
+ * monitor, and explorer categories to emphasize scope.
+ */
+
+/** Global UI/UX tasks derived from core principles. */
+export const globalTasks = {
+  /** Ensure primary actions remain visible without scrolling across the app. */
+  ensureOneScreenOperation(): never {
+    throw new Error('Not implemented: ensureOneScreenOperation');
+  },
+
+  /** Implement a fluid sizing map that responds to font scaling and zoom. */
+  implementFluidSizingMap(): never {
+    throw new Error('Not implemented: implementFluidSizingMap');
+  },
+
+  /** Observe orientation and video aspect without forcing re-mounts. */
+  addOrientationAspectObserver(): never {
+    throw new Error('Not implemented: addOrientationAspectObserver');
+  },
+
+  /** Keep app chrome within safe areas and avoid zoom-on-load. */
+  pinChromeWithSafeArea(): never {
+    throw new Error('Not implemented: pinChromeWithSafeArea');
+  },
+
+  /** Treat modals as full apps with sticky headers and stable context. */
+  ensureModalsBehaveLikeApps(): never {
+    throw new Error('Not implemented: ensureModalsBehaveLikeApps');
+  },
+
+  /** Honor system font scaling, reduced motion, and safe-area insets. */
+  honorUserSettings(): never {
+    throw new Error('Not implemented: honorUserSettings');
+  },
+
+  /** Prevent accidental browser gestures like pull-to-refresh. */
+  gateBrowserGestures(): never {
+    throw new Error('Not implemented: gateBrowserGestures');
+  },
+
+  /** Add acceptance tests covering rotation, zoom, and modal states. */
+  introduceAcceptanceTests(): never {
+    throw new Error('Not implemented: introduceAcceptanceTests');
+  },
+
+  /** Wire telemetry for layout passes, rotations, and below-fold controls. */
+  wireLayoutTelemetry(): never {
+    throw new Error('Not implemented: wireLayoutTelemetry');
+  },
+
+  /** Conduct an accessibility pass for names, roles, and contrast. */
+  conductAccessibilityPass(): never {
+    throw new Error('Not implemented: conductAccessibilityPass');
+  },
+
+  /** Provide a fallback density scale for developer mode without font hacks. */
+  createFallbackDensityScale(): never {
+    throw new Error('Not implemented: createFallbackDensityScale');
+  },
+} as const;
+
+/** Camera Monitor specific tasks. */
+export const monitorTasks = {
+  /** Define Monitor layout regions and video box sizing contract. */
+  defineMonitorLayoutContract(): never {
+    throw new Error('Not implemented: defineMonitorLayoutContract');
+  },
+
+  /** Refactor record/monitor/display/audio controls into a responsive bar. */
+  refactorControlGroups(): never {
+    throw new Error('Not implemented: refactorControlGroups');
+  },
+
+  /** Ensure Monitor never scrolls vertically on phone portrait. */
+  enforceNoScrollMonitor(): never {
+    throw new Error('Not implemented: enforceNoScrollMonitor');
+  },
+
+  /** Overlay diagnostics drawer without pushing controls offscreen. */
+  addDiagnosticsDrawer(): never {
+    throw new Error('Not implemented: addDiagnosticsDrawer');
+  },
+
+  /** Optimize video frame pipeline for GPU scaling and low CPU churn. */
+  optimizeVideoFramePipeline(): never {
+    throw new Error('Not implemented: optimizeVideoFramePipeline');
+  },
+} as const;
+
+/** Explorer modal related tasks. */
+export const explorerTasks = {
+  /** Modal shell with sticky header and isolated scroll area. */
+  createStickyModalShell(): never {
+    throw new Error('Not implemented: createStickyModalShell');
+  },
+
+  /** Preserve modal state on rotation while keeping scroll position. */
+  addModalRotationPersistence(): never {
+    throw new Error('Not implemented: addModalRotationPersistence');
+  },
+} as const;
+
+/** Combined map of all UI/UX tasks for easy iteration. */
+export const uiUxTasks = {
+  ...globalTasks,
+  ...monitorTasks,
+  ...explorerTasks,
+} as const;
+
+export type UiUxTaskName = keyof typeof uiUxTasks;
+
+export const taskNames = Object.keys(uiUxTasks) as UiUxTaskName[];
+
+export const {
+  ensureOneScreenOperation,
+  implementFluidSizingMap,
+  addOrientationAspectObserver,
+  pinChromeWithSafeArea,
+  ensureModalsBehaveLikeApps,
+  honorUserSettings,
+  gateBrowserGestures,
+  introduceAcceptanceTests,
+  wireLayoutTelemetry,
+  conductAccessibilityPass,
+  createFallbackDensityScale,
+  defineMonitorLayoutContract,
+  refactorControlGroups,
+  enforceNoScrollMonitor,
+  addDiagnosticsDrawer,
+  optimizeVideoFramePipeline,
+  createStickyModalShell,
+  addModalRotationPersistence,
+} = uiUxTasks;
+

--- a/docker/web-app/tsconfig.test.json
+++ b/docker/web-app/tsconfig.test.json
@@ -16,7 +16,8 @@
     "src/hooks/__tests__/useOrientation.test.ts",
     "src/app/__tests__/login.test.tsx",
     "src/app/__tests__/account.test.tsx",
-    "src/app/[tenant]/__tests__/settings.test.tsx"
+    "src/app/[tenant]/__tests__/settings.test.tsx",
+    "src/components/__tests__/uiUxTasks.test.ts"
   ],
   "exclude": []
 }


### PR DESCRIPTION
Milestone: 🧬 Feature Development
Scope: web-app
Linked Issues: N/A

## Summary
- group global, monitor, and explorer implementation tasks in typed stub module
- ensure every UI/UX stub throws "Not implemented" through a dedicated test

## Testing
- `npm install`
- `npm test`

## Checklist
- [ ] Code is self-contained and idempotent.
- [ ] No unnecessary new files or external dependencies.
- [ ] Tests added or updated as appropriate.
- [ ] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_68a89828ed3c83268aeaa35fbae00771