### PR TITLE
feat: add orientation-aspect observer and task stubs

### DIFF
--- a/docker/web-app/src/components/CameraMonitor/index.tsx
+++ b/docker/web-app/src/components/CameraMonitor/index.tsx
@@ -11,7 +11,8 @@ import { useCameraStream } from "@/hooks/useCameraStream";
 import RecordButton from "@/components/RecordButton";
 import { useModal } from "@/providers/ModalProvider";
 import { sliderBackgroundStyle, batteryLevelStyle } from "@/styles/theme";
-import { useOrientation } from "@/hooks/useOrientation";
+import useOrientationAspect from "@/hooks/useOrientationAspect";
+import useVideoBox from "@/hooks/useVideoBox";
 
 // overlays (no-SSR)
 const FocusPeakingOverlay = dynamic(
@@ -484,7 +485,8 @@ const CameraMonitor: React.FC = () => {
     }
   }, []);
 
-  const orientation = useOrientation();
+  const { orientation } = useOrientationAspect(mediaRef);
+  const { width: boxWidth, height: boxHeight } = useVideoBox(mediaRef);
 
   return (
     <div className="w-full h-screen min-h-[100dvh] bg-gradient-to-br from-gray-900 to-black text-white font-sans overflow-hidden select-none flex flex-col">
@@ -578,13 +580,18 @@ const CameraMonitor: React.FC = () => {
 
       {/* Main Content Area */}
       <div className={`flex flex-1 ${orientation === 'portrait' ? 'flex-col' : ''}`}>
-        <div className={`flex-1 bg-black relative m-2 border-2 border-gray-700 rounded flex items-center justify-center overflow-hidden`}>
+        <div
+          className={`flex-1 bg-black relative m-2 border-2 border-gray-700 rounded flex items-center justify-center overflow-hidden`}
+        >
           {/* 1) The preview wrapper */}
-          <div className="relative max-w-full">
+          <div
+            className="relative"
+            style={{ width: boxWidth, height: boxHeight }}
+          >
             <video
               ref={mediaRef}
               src={streamSrc}
-              className="camera-video-feed max-w-full h-auto"
+              className="camera-video-feed w-full h-full object-contain"
               controls
               autoPlay
               muted

--- a/docker/web-app/src/components/__tests__/uiUxTasks.test.ts
+++ b/docker/web-app/src/components/__tests__/uiUxTasks.test.ts
@@ -1,0 +1,17 @@
+/**
+ * Ensures every UI/UX task stub exists and throws "Not implemented".
+ *
+ * Run with: npm test
+ */
+import test from 'node:test'
+import assert from 'node:assert'
+import { uiUxTasks, taskNames } from '../uiUxTasks'
+
+test('UI/UX task stubs throw not implemented', () => {
+  for (const name of taskNames) {
+    const fn = uiUxTasks[name]
+    assert.strictEqual(typeof fn, 'function', `${name} should be a function`)
+    assert.throws(() => fn(), /Not implemented/)
+  }
+})
+

--- a/docker/web-app/src/components/uiUxTasks.ts
+++ b/docker/web-app/src/components/uiUxTasks.ts
@@ -1,0 +1,136 @@
+/**
+ * Task stubs for the Camera Monitor and Explorer mobile-first specification.
+ * Each function represents an implementation task from
+ * docs/TECHNICAL/CAMERA_MONITOR_EXPLORER_SPEC.md.
+ *
+ * Usage: import individual functions or iterate over `uiUxTasks` to
+ * drive future implementation work. Tasks are grouped into global,
+ * monitor, and explorer categories to emphasize scope.
+ */
+
+/** Global UI/UX tasks derived from core principles. */
+export const globalTasks = {
+  /** Ensure primary actions remain visible without scrolling across the app. */
+  ensureOneScreenOperation(): never {
+    throw new Error('Not implemented: ensureOneScreenOperation');
+  },
+
+  /** Implement a fluid sizing map that responds to font scaling and zoom. */
+  implementFluidSizingMap(): never {
+    throw new Error('Not implemented: implementFluidSizingMap');
+  },
+
+
+  /** Keep app chrome within safe areas and avoid zoom-on-load. */
+  pinChromeWithSafeArea(): never {
+    throw new Error('Not implemented: pinChromeWithSafeArea');
+  },
+
+  /** Treat modals as full apps with sticky headers and stable context. */
+  ensureModalsBehaveLikeApps(): never {
+    throw new Error('Not implemented: ensureModalsBehaveLikeApps');
+  },
+
+  /** Honor system font scaling, reduced motion, and safe-area insets. */
+  honorUserSettings(): never {
+    throw new Error('Not implemented: honorUserSettings');
+  },
+
+  /** Prevent accidental browser gestures like pull-to-refresh. */
+  gateBrowserGestures(): never {
+    throw new Error('Not implemented: gateBrowserGestures');
+  },
+
+  /** Add acceptance tests covering rotation, zoom, and modal states. */
+  introduceAcceptanceTests(): never {
+    throw new Error('Not implemented: introduceAcceptanceTests');
+  },
+
+  /** Wire telemetry for layout passes, rotations, and below-fold controls. */
+  wireLayoutTelemetry(): never {
+    throw new Error('Not implemented: wireLayoutTelemetry');
+  },
+
+  /** Conduct an accessibility pass for names, roles, and contrast. */
+  conductAccessibilityPass(): never {
+    throw new Error('Not implemented: conductAccessibilityPass');
+  },
+
+  /** Provide a fallback density scale for developer mode without font hacks. */
+  createFallbackDensityScale(): never {
+    throw new Error('Not implemented: createFallbackDensityScale');
+  },
+} as const;
+
+/** Camera Monitor specific tasks. */
+export const monitorTasks = {
+  /** Define Monitor layout regions and video box sizing contract. */
+  defineMonitorLayoutContract(): never {
+    throw new Error('Not implemented: defineMonitorLayoutContract');
+  },
+
+  /** Refactor record/monitor/display/audio controls into a responsive bar. */
+  refactorControlGroups(): never {
+    throw new Error('Not implemented: refactorControlGroups');
+  },
+
+  /** Ensure Monitor never scrolls vertically on phone portrait. */
+  enforceNoScrollMonitor(): never {
+    throw new Error('Not implemented: enforceNoScrollMonitor');
+  },
+
+  /** Overlay diagnostics drawer without pushing controls offscreen. */
+  addDiagnosticsDrawer(): never {
+    throw new Error('Not implemented: addDiagnosticsDrawer');
+  },
+
+  /** Optimize video frame pipeline for GPU scaling and low CPU churn. */
+  optimizeVideoFramePipeline(): never {
+    throw new Error('Not implemented: optimizeVideoFramePipeline');
+  },
+} as const;
+
+/** Explorer modal related tasks. */
+export const explorerTasks = {
+  /** Modal shell with sticky header and isolated scroll area. */
+  createStickyModalShell(): never {
+    throw new Error('Not implemented: createStickyModalShell');
+  },
+
+  /** Preserve modal state on rotation while keeping scroll position. */
+  addModalRotationPersistence(): never {
+    throw new Error('Not implemented: addModalRotationPersistence');
+  },
+} as const;
+
+/** Combined map of all UI/UX tasks for easy iteration. */
+export const uiUxTasks = {
+  ...globalTasks,
+  ...monitorTasks,
+  ...explorerTasks,
+} as const;
+
+export type UiUxTaskName = keyof typeof uiUxTasks;
+
+export const taskNames = Object.keys(uiUxTasks) as UiUxTaskName[];
+
+export const {
+  ensureOneScreenOperation,
+  implementFluidSizingMap,
+  pinChromeWithSafeArea,
+  ensureModalsBehaveLikeApps,
+  honorUserSettings,
+  gateBrowserGestures,
+  introduceAcceptanceTests,
+  wireLayoutTelemetry,
+  conductAccessibilityPass,
+  createFallbackDensityScale,
+  defineMonitorLayoutContract,
+  refactorControlGroups,
+  enforceNoScrollMonitor,
+  addDiagnosticsDrawer,
+  optimizeVideoFramePipeline,
+  createStickyModalShell,
+  addModalRotationPersistence,
+} = uiUxTasks;
+

--- a/docker/web-app/src/hooks/__tests__/useOrientationAspect.test.ts
+++ b/docker/web-app/src/hooks/__tests__/useOrientationAspect.test.ts
@@ -1,0 +1,14 @@
+import assert from 'node:assert';
+import test from 'node:test';
+import { getAspect } from '../useOrientationAspect';
+
+test('calculates aspect ratio', () => {
+  const aspect = getAspect({ width: 16, height: 9 });
+  assert.notEqual(aspect, null);
+  assert.ok(Math.abs((aspect as number) - 16 / 9) < 1e-6);
+});
+
+test('returns null for zero dimensions', () => {
+  const aspect = getAspect({ width: 0, height: 10 });
+  assert.equal(aspect, null);
+});

--- a/docker/web-app/src/hooks/useOrientationAspect.ts
+++ b/docker/web-app/src/hooks/useOrientationAspect.ts
@@ -1,0 +1,48 @@
+/**
+ * useOrientationAspect - track device orientation and the aspect ratio of a referenced element.
+ *
+ * Example:
+ * ```tsx
+ * const ref = useRef<HTMLVideoElement>(null);
+ * const { orientation, aspect } = useOrientationAspect(ref);
+ * ```
+ */
+import { useState, useEffect, RefObject } from 'react';
+import { useOrientation, Orientation } from './useOrientation';
+
+export interface OrientationAspect {
+  orientation: Orientation;
+  aspect: number | null;
+}
+
+/**
+ * Pure helper that calculates an aspect ratio from a rect-like object.
+ */
+export function getAspect(rect: { width: number; height: number }): number | null {
+  if (!rect.width || !rect.height) return null;
+  return rect.width / rect.height;
+}
+
+export default function useOrientationAspect<T extends HTMLElement>(
+  ref: RefObject<T>
+): OrientationAspect {
+  const orientation = useOrientation();
+  const [aspect, setAspect] = useState<number | null>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el || typeof ResizeObserver === 'undefined') return;
+
+    const update = () => {
+      const rect = el.getBoundingClientRect();
+      setAspect(getAspect(rect));
+    };
+
+    update();
+    const ro = new ResizeObserver(update);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [ref]);
+
+  return { orientation, aspect };
+}

--- a/docker/web-app/src/hooks/useVideoBox.ts
+++ b/docker/web-app/src/hooks/useVideoBox.ts
@@ -1,0 +1,44 @@
+/**
+ * useVideoBox - compute letterboxed size for a video element inside its parent container.
+ * Ensures video never overflows and preserves aspect ratio.
+ *
+ * Example:
+ * ```tsx
+ * const ref = useRef<HTMLVideoElement>(null);
+ * const box = useVideoBox(ref);
+ * return <video ref={ref} style={{ width: box.width, height: box.height }} />
+ * ```
+ */
+import { useState, useEffect, RefObject } from 'react';
+import fitRect from '../lib/fitRect';
+
+export interface VideoBox { width: number; height: number }
+
+export default function useVideoBox(ref: RefObject<HTMLVideoElement>): VideoBox {
+  const [box, setBox] = useState<VideoBox>({ width: 0, height: 0 });
+
+  useEffect(() => {
+    const video = ref.current;
+    const container = video?.parentElement;
+    if (!video || !container || typeof ResizeObserver === 'undefined') return;
+
+    const update = () => {
+      const cw = container.clientWidth;
+      const ch = container.clientHeight;
+      const vw = video.videoWidth || cw;
+      const vh = video.videoHeight || ch;
+      setBox(fitRect({ width: cw, height: ch }, { width: vw, height: vh }));
+    };
+
+    update();
+    const ro = new ResizeObserver(update);
+    ro.observe(container);
+    video.addEventListener('loadedmetadata', update);
+    return () => {
+      ro.disconnect();
+      video.removeEventListener('loadedmetadata', update);
+    };
+  }, [ref]);
+
+  return box;
+}

--- a/docker/web-app/src/lib/__tests__/fitRect.test.ts
+++ b/docker/web-app/src/lib/__tests__/fitRect.test.ts
@@ -1,0 +1,18 @@
+import test from 'node:test'
+import assert from 'node:assert'
+import { fitRect } from '../fitRect'
+
+test('fits width when container narrower than media', () => {
+  const box = fitRect({ width: 100, height: 100 }, { width: 200, height: 100 })
+  assert.deepStrictEqual(box, { width: 100, height: 50 })
+})
+
+test('fits height when container taller than media', () => {
+  const box = fitRect({ width: 200, height: 100 }, { width: 100, height: 200 })
+  assert.deepStrictEqual(box, { width: 50, height: 100 })
+})
+
+test('returns zero when any dimension missing', () => {
+  const box = fitRect({ width: 0, height: 100 }, { width: 100, height: 50 })
+  assert.deepStrictEqual(box, { width: 0, height: 0 })
+})

--- a/docker/web-app/src/lib/fitRect.ts
+++ b/docker/web-app/src/lib/fitRect.ts
@@ -1,0 +1,27 @@
+/**
+ * Calculate dimensions to fit a media box inside a container while preserving aspect ratio.
+ * Letterboxes the media when container and media aspect ratios differ.
+ */
+export function fitRect(
+  container: { width: number; height: number },
+  media: { width: number; height: number }
+): { width: number; height: number } {
+  const cAspect = container.width / container.height;
+  const mAspect = media.width / media.height;
+
+  if (!container.width || !container.height || !media.width || !media.height) {
+    return { width: 0, height: 0 };
+  }
+
+  if (cAspect > mAspect) {
+    const height = container.height;
+    const width = height * mAspect;
+    return { width, height };
+  }
+
+  const width = container.width;
+  const height = width / mAspect;
+  return { width, height };
+}
+
+export default fitRect;

--- a/docker/web-app/src/styles/__tests__/tokens.test.ts
+++ b/docker/web-app/src/styles/__tests__/tokens.test.ts
@@ -1,0 +1,16 @@
+import test from 'node:test'
+import fs from 'node:fs'
+import path from 'node:path'
+import assert from 'node:assert'
+
+const css = fs.readFileSync(path.join(process.cwd(), 'src/styles/tokens.css'), 'utf8')
+
+test('defines fluid type scale', () => {
+  assert.match(css, /--fs-sm: clamp/)
+  assert.match(css, /--fs-xl: clamp/)
+})
+
+test('defines fluid spacing scale', () => {
+  assert.match(css, /--space-sm: clamp/)
+  assert.match(css, /--space-lg: clamp/)
+})

--- a/docker/web-app/src/styles/tokens.css
+++ b/docker/web-app/src/styles/tokens.css
@@ -154,6 +154,19 @@
   --text-body: 1rem;        /* 16 */
   --text-heading: 1.25rem;  /* 20 */
 
+  /* Fluid type scale */
+  --fs-xs: clamp(0.75rem, 0.7rem + 0.5vw, 0.875rem);
+  --fs-sm: clamp(0.875rem, 0.82rem + 0.5vw, 1rem);
+  --fs-md: clamp(1rem, 0.95rem + 0.5vw, 1.125rem);
+  --fs-lg: clamp(1.125rem, 1.05rem + 0.5vw, 1.25rem);
+  --fs-xl: clamp(1.25rem, 1.15rem + 0.5vw, 1.5rem);
+
+  /* Fluid spacing scale */
+  --space-xs: clamp(0.25rem, 0.2rem + 0.4vw, 0.5rem);
+  --space-sm: clamp(0.5rem, 0.4rem + 0.6vw, 1rem);
+  --space-md: clamp(0.75rem, 0.6rem + 0.8vw, 1.5rem);
+  --space-lg: clamp(1rem, 0.8rem + 1vw, 2rem);
+
   /* Radii */
   --radius-sm: 6px;
   --radius-md: 10px;

--- a/docker/web-app/tsconfig.test.json
+++ b/docker/web-app/tsconfig.test.json
@@ -14,9 +14,13 @@
     "src/lib/__tests__/videoApi.trimIdle.test.ts",
     "src/providers/__tests__/reactDevtools.test.tsx",
     "src/hooks/__tests__/useOrientation.test.ts",
+    "src/hooks/__tests__/useOrientationAspect.test.ts",
     "src/app/__tests__/login.test.tsx",
     "src/app/__tests__/account.test.tsx",
-    "src/app/[tenant]/__tests__/settings.test.tsx"
+    "src/app/[tenant]/__tests__/settings.test.tsx",
+    "src/components/__tests__/uiUxTasks.test.ts",
+    "src/lib/__tests__/fitRect.test.ts",
+    "src/styles/__tests__/tokens.test.ts"
   ],
   "exclude": []
 }


### PR DESCRIPTION
Milestone: 🧬 Feature Development
Scope: web-app
Linked Issues: N/A

## Summary
- group global, monitor, and explorer implementation tasks in typed stub module
- add orientation/aspect observer hook and use it in camera monitor to size video viewport
- letterbox camera feed with fluid sizing utilities and tokens

## Testing
- `npm install`
- `npm test`

## Checklist
- [ ] Code is self-contained and idempotent.
- [ ] No unnecessary new files or external dependencies.
- [ ] Tests added or updated as appropriate.
- [ ] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_68a89828ed3c83268aeaa35fbae00771