### PR TITLE
feat(web): scaffold tenancy and account ui copy

### DIFF
--- a/docker/web-app/src/app/[tenant]/__tests__/settings.test.tsx
+++ b/docker/web-app/src/app/[tenant]/__tests__/settings.test.tsx
@@ -14,6 +14,6 @@ test('SettingsPage shows general tab', () => {
       <SettingsPage />
     </TenantProvider>
   );
-  assert.ok(html.includes('General'));
+  assert.ok(html.includes('General &amp; Branding'));
 });
 

--- a/docker/web-app/src/app/[tenant]/dashboard/__tests__/AccessPage.test.tsx
+++ b/docker/web-app/src/app/[tenant]/dashboard/__tests__/AccessPage.test.tsx
@@ -1,0 +1,33 @@
+/**
+ * Access control page render tests.
+ * Run with: npm test
+ */
+import assert from 'node:assert';
+import test from 'node:test';
+import { renderToString } from 'react-dom/server';
+import AccessPage from '../access/page';
+import { apiGateway } from '../../../../lib/api';
+
+test('shows fallback when service unreachable', async () => {
+  const original = apiGateway.credentials;
+  apiGateway.credentials = async () => {
+    throw new Error('fail');
+  };
+  try {
+    const html = renderToString(await AccessPage());
+    assert.ok(html.includes('Unable to fetch members'));
+  } finally {
+    apiGateway.credentials = original;
+  }
+});
+
+test('shows empty state when no members', async () => {
+  const original = apiGateway.credentials;
+  apiGateway.credentials = async () => [];
+  try {
+    const html = renderToString(await AccessPage());
+    assert.ok(html.includes('No members in this tenant yet.'));
+  } finally {
+    apiGateway.credentials = original;
+  }
+});

--- a/docker/web-app/src/app/[tenant]/dashboard/access/page.tsx
+++ b/docker/web-app/src/app/[tenant]/dashboard/access/page.tsx
@@ -1,34 +1,61 @@
 // /docker/web-app/src/app/[tenant]/dashboard/access/page.tsx
-// Displays credential list from api-gateway for access control.
-import { apiGateway } from '../../../../lib/api'
+// Displays membership list from api-gateway for access control.
+import { apiGateway } from '../../../../lib/api';
 
-export const metadata = { title: 'Access Control • That DAM Toolbox' }
+export const metadata = { title: 'Access Control • That DAM Toolbox' };
 
 export default async function AccessPage() {
   try {
-    const creds = await apiGateway.credentials()
+    const members = await apiGateway.credentials();
     return (
-      <div>
+      <section>
         <h1 className="text-2xl font-semibold mb-4">Access Control</h1>
-        {Array.isArray(creds) && creds.length > 0 ? (
-          <ul className="space-y-2">
-            {creds.map((c: any, idx: number) => (
-              <li key={c.id ?? idx} className="p-2 border rounded">
-                {c.name || c.id || JSON.stringify(c)}
-              </li>
-            ))}
-          </ul>
+        <button className="px-3 py-1 border rounded mb-4">Invite Member</button>
+        {Array.isArray(members) && members.length > 0 ? (
+          <table className="w-full text-left border">
+            <thead>
+              <tr>
+                <th className="p-2 border-b">Member</th>
+                <th className="p-2 border-b">Roles</th>
+                <th className="p-2 border-b">Last Active</th>
+              </tr>
+            </thead>
+            <tbody>
+              {members.map((m: any, idx: number) => (
+                <tr key={m.id ?? idx} className="border-b">
+                  <td className="p-2">{m.user || m.name || m.id}</td>
+                  <td className="p-2">{m.role || '-'}</td>
+                  <td className="p-2">{m.lastActive || '-'}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
         ) : (
-          <p className="text-gray-500">No credentials found</p>
+          <p className="text-gray-500">No members in this tenant yet.</p>
         )}
-      </div>
-    )
+
+        <div className="mt-8">
+          <h2 className="font-medium mb-2">Test SSO Rules</h2>
+          <input
+            type="email"
+            placeholder="user@example.com"
+            className="border p-1 mr-2"
+          />
+          <button className="px-3 py-1 border rounded">Check Email</button>
+        </div>
+
+        <div className="mt-8">
+          <h2 className="font-medium mb-2">Access Changes</h2>
+          <p className="text-gray-500">No recent access changes.</p>
+        </div>
+      </section>
+    );
   } catch {
     return (
-      <div>
+      <section>
         <h1 className="text-2xl font-semibold mb-4">Access Control</h1>
-        <p className="text-red-500">Access service unreachable</p>
-      </div>
-    )
+        <p className="text-red-500">Unable to fetch members. Please refresh.</p>
+      </section>
+    );
   }
 }

--- a/docker/web-app/src/app/[tenant]/settings/page.tsx
+++ b/docker/web-app/src/app/[tenant]/settings/page.tsx
@@ -4,7 +4,52 @@
 
 import { useState } from 'react';
 
-const tabs = ['General', 'SSO', 'Storage', 'Capture', 'Permissions'];
+const tabs = [
+  'General & Branding',
+  'Domains',
+  'SSO',
+  'Storage',
+  'Capture Defaults',
+  'Permissions Model',
+  'Audit Log',
+];
+
+const copy = {
+  general: {
+    empty: 'No branding set yet. Add a name and logo to make this tenant yours.',
+    error: 'Unable to update branding. Check your permissions and try again.',
+    success: 'Branding updated.',
+  },
+  domains: {
+    empty: 'No custom domains connected.',
+    error: 'Domain update failed. Please verify DNS settings.',
+    success: 'Domain settings saved.',
+  },
+  sso: {
+    empty: 'SSO is disabled for this tenant.',
+    error: "SSO configuration couldn’t be saved. Check values and permissions.",
+    success: 'SSO policy updated.',
+  },
+  storage: {
+    empty: 'No storage backend configured.',
+    error: "Storage settings couldn’t be saved. Confirm endpoint details.",
+    success: 'Storage settings saved.',
+  },
+  capture: {
+    empty: 'No default capture settings defined.',
+    error: 'Failed to update capture defaults.',
+    success: 'Capture defaults saved.',
+  },
+  permissions: {
+    empty: 'No permissions model configured.',
+    error: 'Permissions model update failed.',
+    success: 'Permissions model saved.',
+  },
+  audit: {
+    empty: 'No recent settings changes.',
+    error: 'Couldn’t load audit log.',
+  },
+};
 
 export default function TenantSettingsPage() {
   const [tab, setTab] = useState(0);
@@ -21,11 +66,57 @@ export default function TenantSettingsPage() {
           </button>
         ))}
       </div>
-      {tab === 0 && <p />}
-      {tab === 1 && <p />}
-      {tab === 2 && <p />}
-      {tab === 3 && <p />}
-      {tab === 4 && <p />}
+      {tab === 0 && (
+        <div>
+          <label className="block mb-1">Tenant Name</label>
+          <label className="block mb-1">Logo</label>
+          <label className="block mb-1">Theme</label>
+          <button className="mt-2 px-4 py-2 bg-blue-600 text-white">Save Changes</button>
+          <p className="text-gray-500 mt-4">{copy.general.empty}</p>
+        </div>
+      )}
+      {tab === 1 && (
+        <div>
+          <label className="block mb-1">Default Subdomain</label>
+          <label className="block mb-1">Custom Domains</label>
+          <p className="text-gray-500 mt-4">{copy.domains.empty}</p>
+        </div>
+      )}
+      {tab === 2 && (
+        <div>
+          <label className="block mb-1">Enable SSO</label>
+          <label className="block mb-1">Allowed Domains</label>
+          <label className="block mb-1">Enforce Google-only Sign-in</label>
+          <p className="text-gray-500 mt-4">{copy.sso.empty}</p>
+        </div>
+      )}
+      {tab === 3 && (
+        <div>
+          <label className="block mb-1">Endpoint</label>
+          <label className="block mb-1">Bucket</label>
+          <p className="text-gray-500 mt-4">{copy.storage.empty}</p>
+        </div>
+      )}
+      {tab === 4 && (
+        <div>
+          <label className="block mb-1">Frame Rate (fps)</label>
+          <label className="block mb-1">Codec</label>
+          <label className="block mb-1">Overlay Profile</label>
+          <p className="text-gray-500 mt-4">{copy.capture.empty}</p>
+        </div>
+      )}
+      {tab === 5 && (
+        <div>
+          <label className="block mb-1">RBAC Scheme</label>
+          <label className="block mb-1">Policy Preview</label>
+          <p className="text-gray-500 mt-4">{copy.permissions.empty}</p>
+        </div>
+      )}
+      {tab === 6 && (
+        <div>
+          <p className="text-gray-500">{copy.audit.empty}</p>
+        </div>
+      )}
     </section>
   );
 }

--- a/docker/web-app/src/app/__tests__/account.test.tsx
+++ b/docker/web-app/src/app/__tests__/account.test.tsx
@@ -7,8 +7,8 @@ import test from 'node:test';
 import { renderToString } from 'react-dom/server';
 import AccountPage from '../account/page';
 
-test('AccountPage shows heading', () => {
+test('AccountPage shows profile section', () => {
   const html = renderToString(<AccountPage />);
-  assert.ok(html.includes('My Account'));
+  assert.ok(html.includes('Profile'));
 });
 

--- a/docker/web-app/src/app/account/page.tsx
+++ b/docker/web-app/src/app/account/page.tsx
@@ -5,7 +5,24 @@
 export default function AccountPage() {
   return (
     <section className="max-w-md mx-auto py-8">
-      <h1 className="text-2xl font-bold mb-4">My Account</h1>
+      <h1 className="text-2xl font-bold mb-4">Account</h1>
+
+      <h2 className="text-xl font-semibold mt-6 mb-2">Profile</h2>
+      <label className="block mb-1">Name</label>
+      <label className="block mb-1">Avatar</label>
+      <label className="block mb-1">Time Zone</label>
+
+      <h2 className="text-xl font-semibold mt-6 mb-2">Security</h2>
+      <label className="block mb-1">Multi-Factor Authentication</label>
+      <button className="px-3 py-1 border rounded mb-2">Enable MFA</button>
+      <label className="block mb-1">Recovery Factors</label>
+
+      <h2 className="text-xl font-semibold mt-6 mb-2">Connected Identities</h2>
+      <p className="mb-2">Google Account: Not connected</p>
+      <button className="px-3 py-1 border rounded mb-2">Disconnect Google</button>
+
+      <h2 className="text-xl font-semibold mt-6 mb-2">Default Tenant</h2>
+      <label className="block mb-1">Preferred Tenant</label>
     </section>
   );
 }


### PR DESCRIPTION
Milestone: 🧬 Feature Development
Scope: web-app
Linked Issues: none

## Summary
- add placeholder tenant settings tabs and copy
- scaffold access control page with table, invite action, and sso tester
- expand account page with profile, security, and identity sections

## Testing
- `npm test`

## Checklist
- [x] Code is self-contained and idempotent.
- [x] No unnecessary new files or external dependencies.
- [x] Tests added or updated as appropriate.
- [ ] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_68a8a6e08e58832693cd37e363e51d5d