### PR TITLE
fix: handle missing supervisor plan

### DIFF
--- a/host/services/shared/supervisor/client.go
+++ b/host/services/shared/supervisor/client.go
@@ -131,6 +131,10 @@ func FetchPlan(ctx context.Context, reqPayload any) (plan.DesiredPlan, error) {
 		return dp, err
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		io.CopyN(io.Discard, resp.Body, 1024)
+		return dp, nil
+	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		io.CopyN(io.Discard, resp.Body, 1024)
 		return dp, fmt.Errorf("supervisor plan: %s", resp.Status)

--- a/host/services/shared/supervisor/client_test.go
+++ b/host/services/shared/supervisor/client_test.go
@@ -46,3 +46,17 @@ func TestFetchPlan(t *testing.T) {
 		t.Fatalf("fetch plan failed: %v %#v", err, dp)
 	}
 }
+
+func TestFetchPlanNotFound(t *testing.T) {
+	ts := httptest.NewServer(http.NotFoundHandler())
+	defer ts.Close()
+	os.Setenv("SUPERVISOR_URL", ts.URL+"/v1/nodes")
+	t.Cleanup(func() { os.Unsetenv("SUPERVISOR_URL") })
+	dp, err := FetchPlan(context.Background(), map[string]string{"node_id": "n1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if dp.Node != "" || len(dp.Apps) != 0 {
+		t.Fatalf("expected zero plan, got %#v", dp)
+	}
+}


### PR DESCRIPTION
Milestone: 🧬 Feature Development
Scope: host/services/shared, host/services/runner
Linked Issues: none

## Summary
- treat 404 responses from supervisor plan endpoint as empty plans
- add test ensuring FetchPlan returns zero plan on 404

## Testing
- `go test ./host/services/shared/supervisor -count=1`
- `go test ./host/services/runner/... -v -count=1`

## Checklist
- [x] Code is self-contained and idempotent.
- [x] No unnecessary new files or external dependencies.
- [x] Tests added or updated as appropriate.
- [x] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_68a8b6ab78f48326b5d457acf53c7ef6