### PR TITLE
fix: remove requests dependency from weaviate bootstrap

### DIFF
--- a/docker/weaviate/test_schema.py
+++ b/docker/weaviate/test_schema.py
@@ -1,11 +1,17 @@
-"""Tests for the Weaviate schema definition.
+"""Tests for the Weaviate schema definition and bootstrap script.
 
 Run with:
     PYTHONPATH=. pytest docker/weaviate/test_schema.py
 """
 
+import io
 import json
+import runpy
+import urllib.error
+import urllib.request
 from pathlib import Path
+
+import pytest
 
 
 def test_schema_json_parses_and_contains_classes():
@@ -15,4 +21,39 @@ def test_schema_json_parses_and_contains_classes():
 
     classes = {cls["class"] for cls in schema.get("classes", [])}
     assert {"VideoAsset", "CaptureDevice", "CaptureEvent"} <= classes
+
+
+def test_bootstrap_script_runs_without_requests(tmp_path, monkeypatch):
+    script_path = Path(__file__).with_name("bootstrap-schema.py")
+    schema_file = tmp_path / "schema.json"
+    schema_file.write_text('{"classes": [{"class": "Foo"}]}')
+
+    monkeypatch.setenv("WEAVIATE_URL", "http://weaviate:8080")
+    monkeypatch.setenv("WEAVIATE_SCHEMA", str(schema_file))
+
+    class DummyResponse:
+        def __init__(self, status: int, data: bytes):
+            self.status = status
+            self._data = data
+
+        def read(self) -> bytes:  # pragma: no cover - trivial
+            return self._data
+
+        def __enter__(self):  # pragma: no cover - trivial
+            return self
+
+        def __exit__(self, exc_type, exc, tb):  # pragma: no cover - trivial
+            return False
+
+    def fake_urlopen(req, timeout=2):
+        url = req if isinstance(req, str) else req.full_url
+        if url.endswith("/v1/.well-known/ready"):
+            return DummyResponse(200, b"ok")
+        raise urllib.error.HTTPError(url, 422, "exists", {}, io.BytesIO(b""))
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    with pytest.raises(SystemExit) as exc:
+        runpy.run_path(str(script_path), run_name="__main__")
+    assert exc.value.code == 0
 


### PR DESCRIPTION
Milestone: 🧬 Feature Development
Scope: docker,weaviate
Linked Issues: n/a

## Summary
- drop external requests dependency from Weaviate schema bootstrap script
- add regression test ensuring bootstrap runs using only the standard library

## Testing
- `pytest docker/weaviate/test_schema.py`

## Checklist
- [x] Code is self-contained and idempotent.
- [x] No unnecessary new files or external dependencies.
- [x] Tests added or updated as appropriate.
- [x] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_68a8b6c8ff488326ae70c6c9e5c7f3ad