### PR TITLE
fix: prevent Weaviate self-join log spam

### DIFF
--- a/docker/compose/docker-compose.weaviate.yaml
+++ b/docker/compose/docker-compose.weaviate.yaml
@@ -36,6 +36,8 @@ services:
 
       # Single-node cluster name
       CLUSTER_HOSTNAME:                          "node1"
+      # Prevent self-join attempts that spam logs in single-node setups
+      CLUSTER_JOIN:                              ""
     volumes:
       - ../../docker/weaviate/data/weaviate:/var/lib/weaviate
     depends_on:

--- a/docker/weaviate/test_compose_config.py
+++ b/docker/weaviate/test_compose_config.py
@@ -1,0 +1,19 @@
+"""Verify Weaviate compose config avoids self-join attempts.
+
+Run with:
+    PYTHONPATH=. pytest docker/weaviate/test_compose_config.py
+"""
+
+from pathlib import Path
+
+import yaml
+
+
+def test_cluster_join_disabled():
+    compose_path = Path(__file__).resolve().parents[1] / "compose" / "docker-compose.weaviate.yaml"
+    with open(compose_path) as f:
+        doc = yaml.safe_load(f)
+
+    env = doc["services"]["weaviate"]["environment"]
+    assert "CLUSTER_JOIN" in env
+    assert env["CLUSTER_JOIN"] == ""


### PR DESCRIPTION
Milestone: 🧬 Feature Development
Scope: docker
Linked Issues: N/A

## Summary
- avoid self-join attempts in single-node Weaviate compose
- test compose config for disabled cluster join

## Testing
- `pytest -q docker/weaviate/test_schema.py docker/weaviate/test_compose_config.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8b6ee2c908326a40789277d2c44c8