### PR TITLE
fix(video-api): handle unwritable data directories

### DIFF
--- a/docker/video-api/entrypoint.sh
+++ b/docker/video-api/entrypoint.sh
@@ -76,7 +76,7 @@ create_directories() {
   for d in "${DATA_DIRS[@]}"; do
     if [[ ! -d "$d" ]]; then
       log "Creating directory: $d"
-      mkdir -p "$d"
+      mkdir -p "$d" 2>/dev/null || log "⚠️  Could not create directory $d (continuing anyway)"
     fi
   done
 }

--- a/script_tests/test_video_api_entrypoint.py
+++ b/script_tests/test_video_api_entrypoint.py
@@ -1,0 +1,44 @@
+"""Tests for docker/video-api/entrypoint.sh directory handling.
+
+Example:
+    pytest script_tests/test_video_api_entrypoint.py -q
+"""
+
+import os
+import pathlib
+import subprocess
+import pwd
+
+SCRIPT = pathlib.Path(__file__).resolve().parents[1] / "docker" / "video-api" / "entrypoint.sh"
+
+
+def test_directory_creation_permission_denied(tmp_path):
+    ro_root = tmp_path / "ro"
+    ro_root.mkdir()
+    ro_root.chmod(0o555)
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "VIDEO_DATA_DIR": str(ro_root),
+            "VIDEO_MEDIA_ROOT": str(ro_root / "media"),
+            "MODULES_ROOT": str(ro_root / "modules"),
+        }
+    )
+
+    nobody = pwd.getpwnam("nobody")
+
+    def demote():
+        os.setgid(nobody.pw_gid)
+        os.setuid(nobody.pw_uid)
+
+    result = subprocess.run(
+        ["bash", str(SCRIPT), "echo", "ok"],
+        env=env,
+        text=True,
+        capture_output=True,
+        preexec_fn=demote,
+    )
+
+    assert result.returncode == 0
+    assert "Could not create directory" in result.stderr


### PR DESCRIPTION
Milestone: 🧬 Feature Development
Scope: video-api
Linked Issues: N/A

## Summary
- handle unwritable data directories gracefully in video-api entrypoint
- add regression test for directory creation permissions

## Testing
- `pytest script_tests -q`

## Checklist
- [ ] Code is self-contained and idempotent.
- [ ] No unnecessary new files or external dependencies.
- [ ] Tests added or updated as appropriate.
- [ ] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_68a8b74a09548326a61a66f7c534fb0e