### PR TITLE
fix: silence mdns close logs in discovery service

### DIFF
--- a/host/services/discovery/internal/manager/manager_test.go
+++ b/host/services/discovery/internal/manager/manager_test.go
@@ -1,10 +1,13 @@
 package manager
 
 import (
+	"bytes"
 	"encoding/json"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/Cdaprod/ThatDamToolbox/host/services/shared/supervisor/plan"
@@ -41,5 +44,21 @@ func TestStartProxyModeUsesPlan(t *testing.T) {
 	defer os.Unsetenv("SUPERVISOR_URL")
 	if err := dm.startProxyMode(); err != nil {
 		t.Fatalf("startProxyMode: %v", err)
+	}
+}
+
+func TestSilenceMDNSLogs(t *testing.T) {
+	buf := &bytes.Buffer{}
+	orig := log.Writer()
+	log.SetOutput(buf)
+	silenceMDNSLogs()
+	log.Println("[INFO] mdns: Closing client 123")
+	log.Println("keep")
+	log.SetOutput(orig)
+	if strings.Contains(buf.String(), "Closing client") {
+		t.Fatalf("mdns close log was not filtered: %s", buf.String())
+	}
+	if !strings.Contains(buf.String(), "keep") {
+		t.Fatalf("expected non-mdns logs to remain: %s", buf.String())
 	}
 }


### PR DESCRIPTION
Milestone: 🧬 Feature Development
Scope: discovery
Linked Issues: none

## Summary
- filter hashicorp/mdns "Closing client" messages to reduce log noise
- add regression test for mdns log filtering

## Testing
- `go test ./...`

## Checklist
- [x] Code is self-contained and idempotent.
- [x] No unnecessary new files or external dependencies.
- [x] Tests added or updated as appropriate.
- [x] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_68a8b7b9141c832689118f8db3a5a925