### PR TITLE
fix: default rabbitmq entrypoint command

### DIFF
--- a/docker/rabbitmq/entrypoint.sh
+++ b/docker/rabbitmq/entrypoint.sh
@@ -17,5 +17,10 @@ if command -v rabbitmqctl >/dev/null 2>&1; then
 else
   echo "rabbitmqctl not found; skipping feature flag enable" >&2
 fi
+if [[ $# -eq 0 ]]; then
+  set -- rabbitmq-server
+fi
 
+# disable unbound variable check before delegating; the upstream script doesn't enable it
+set +u
 exec docker-entrypoint.sh "$@"

--- a/script_tests/test_rabbitmq_entrypoint.py
+++ b/script_tests/test_rabbitmq_entrypoint.py
@@ -5,15 +5,15 @@ import subprocess
 SCRIPT = pathlib.Path(__file__).resolve().parents[1] / "docker" / "rabbitmq" / "entrypoint.sh"
 
 
-def test_enables_feature_flag(tmp_path):
+def test_enables_feature_flag_and_passes_default_command(tmp_path):
     log = tmp_path / "log"
     # stub rabbitmqctl to record invocation
     ctl = tmp_path / "rabbitmqctl"
     ctl.write_text("#!/usr/bin/env bash\n" f"echo rabbitmqctl >> {log}\n")
     ctl.chmod(0o755)
-    # stub docker-entrypoint.sh to avoid launching rabbitmq
+    # stub docker-entrypoint.sh to capture the first argument
     de = tmp_path / "docker-entrypoint.sh"
-    de.write_text("#!/usr/bin/env bash\n" f"echo entrypoint >> {log}\n")
+    de.write_text("#!/usr/bin/env bash\n" f"echo \"$1\" >> {log}\n")
     de.chmod(0o755)
 
     env = os.environ.copy()
@@ -21,4 +21,4 @@ def test_enables_feature_flag(tmp_path):
 
     result = subprocess.run(["bash", str(SCRIPT)], env=env, text=True, capture_output=True)
     assert result.returncode == 0
-    assert log.read_text().splitlines() == ["rabbitmqctl", "entrypoint"]
+    assert log.read_text().splitlines() == ["rabbitmqctl", "rabbitmq-server"]


### PR DESCRIPTION
Milestone: 🧬 Feature Development
Scope: docker
Linked Issues: N/A

## Summary
- ensure rabbitmq entrypoint always passes a default command
- test that default command is forwarded to docker-entrypoint.sh

## Testing
- `pytest -q script_tests/test_rabbitmq_entrypoint.py`

## Checklist
- [x] Code is self-contained and idempotent.
- [x] No unnecessary new files or external dependencies.
- [x] Tests added or updated as appropriate.
- [x] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_68a8b7e891148326a71724ec766d53c7