### PR TITLE
fix: use stable buildx cache path

### DIFF
--- a/README.md
+++ b/README.md
@@ -826,6 +826,9 @@ git clone https://github.com/Cdaprod/ThatDAMToolbox.git
 cd ThatDAMToolbox
 
 # Build Go service images (run from repo root)
+# Optional: avoid /tmp cache issues by pinning BuildKit cache path
+export BUILDX_CACHE_SRC="$HOME/.cache/buildx-cache"
+export BUILDX_CACHE_DEST="$BUILDX_CACHE_SRC"
 docker compose build overlay-hub supervisor runner
 
 # Build and run with Docker Compose

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,10 +11,10 @@ x-build-common: &build-common
   args:
     BUILDKIT_INLINE_CACHE: "1"
   cache_from:
-    - type=local,src=/tmp/buildx-cache
     - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build
+    - type=local,src=${BUILDX_CACHE_SRC:-$HOME/.cache/buildx-cache}
   cache_to:
-    - type=local,dest=/tmp/buildx-cache,mode=max
+    - type=local,dest=${BUILDX_CACHE_DEST:-$HOME/.cache/buildx-cache},mode=max
   labels:
     org.opencontainers.image.source: "https://github.com/Cdaprod/Media-Indexer-Stdlib-Prototype"
     org.opencontainers.image.vendor: "Cdaprod"


### PR DESCRIPTION
Milestone: 🧬 Feature Development
Scope: docker
Linked Issues: N/A

## Summary
- use HOME-based buildx cache with env overrides
- document optional BuildKit cache exports in README

## Testing
- `go test ./tests -run Test -count=1`
- `PYTHONPATH=. pytest tests/test_nginx_entrypoint_snippets.py -q` *(fails: Formatting field not found in record: 'tenant_id')*

------
https://chatgpt.com/codex/tasks/task_e_68a8c522017c8326affd92167f00325a