### PR TITLE
fix: align buildkit cache and bundle viewer deps

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -132,6 +132,8 @@ Local development images use an environment-driven tag so builds stay consistent
 - **Mount the repo root** into your container (`volumes: - ../../:/app`) and add `--reload` to the API command for instant feedback.
 - **Keep dotenv files** (`.env`, `.env.local`) inside `docker/compose/` so they’re easy to share but stay out of the image build context.
 - **Use BuildKit’s inline cache** ⇢ `docker buildx build --cache-to type=inline` ⇢ lightning-fast rebuilds when iterating on one service.
+- **Shared build cache** – compose files pull from `ghcr.io/cdaprod/thatdamtoolbox-cache:build` and default to `${BUILDX_CACHE_DEST:-$HOME/.cache/buildx-cache}`; override `BUILDX_CACHE_SRC` or `BUILDX_CACHE_DEST` as needed.
+- **Enable BuildKit once** – add `{ "features": { "buildkit": true } }` to `~/.docker/config.json` so you don't have to export `DOCKER_BUILDKIT=1` every run.
 
 -----
 

--- a/docker/compose/docker-compose.api-gateway.yaml
+++ b/docker/compose/docker-compose.api-gateway.yaml
@@ -8,9 +8,10 @@ x-build-common: &build-common
   args:
     BUILDKIT_INLINE_CACHE: "1"
   cache_from:
-    - type=local,src=/tmp/buildx-cache
+    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build
+    - type=local,src=${BUILDX_CACHE_SRC:-$HOME/.cache/buildx-cache}
   cache_to:
-    - type=local,dest=/tmp/buildx-cache,mode=max
+    - type=local,dest=${BUILDX_CACHE_DEST:-$HOME/.cache/buildx-cache},mode=max
   labels:
     org.opencontainers.image.source: "https://github.com/Cdaprod/Media-Indexer-Stdlib-Prototype"
     org.opencontainers.image.vendor: "Cdaprod"

--- a/docker/compose/docker-compose.auth-auth0.yaml
+++ b/docker/compose/docker-compose.auth-auth0.yaml
@@ -8,9 +8,10 @@ x-build-common: &build-common
   args:
     BUILDKIT_INLINE_CACHE: "1"
   cache_from:
-    - type=local,src=/tmp/buildx-cache
+    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build
+    - type=local,src=${BUILDX_CACHE_SRC:-$HOME/.cache/buildx-cache}
   cache_to:
-    - type=local,dest=/tmp/buildx-cache,mode=max
+    - type=local,dest=${BUILDX_CACHE_DEST:-$HOME/.cache/buildx-cache},mode=max
   labels:
     org.opencontainers.image.source: "https://github.com/Cdaprod/Media-Indexer-Stdlib-Prototype"
     org.opencontainers.image.vendor: "Cdaprod"

--- a/docker/compose/docker-compose.auth-keycloak.yaml
+++ b/docker/compose/docker-compose.auth-keycloak.yaml
@@ -8,9 +8,10 @@ x-build-common: &build-common
   args:
     BUILDKIT_INLINE_CACHE: "1"
   cache_from:
-    - type=local,src=/tmp/buildx-cache
+    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build
+    - type=local,src=${BUILDX_CACHE_SRC:-$HOME/.cache/buildx-cache}
   cache_to:
-    - type=local,dest=/tmp/buildx-cache,mode=max
+    - type=local,dest=${BUILDX_CACHE_DEST:-$HOME/.cache/buildx-cache},mode=max
   labels:
     org.opencontainers.image.source: "https://github.com/Cdaprod/Media-Indexer-Stdlib-Prototype"
     org.opencontainers.image.vendor: "Cdaprod"

--- a/docker/compose/docker-compose.camera-proxy.yaml
+++ b/docker/compose/docker-compose.camera-proxy.yaml
@@ -8,9 +8,10 @@ x-build-common: &build-common
   args:
     BUILDKIT_INLINE_CACHE: "1"
   cache_from:
-    - type=local,src=/tmp/buildx-cache
+    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build
+    - type=local,src=${BUILDX_CACHE_SRC:-$HOME/.cache/buildx-cache}
   cache_to:
-    - type=local,dest=/tmp/buildx-cache,mode=max
+    - type=local,dest=${BUILDX_CACHE_DEST:-$HOME/.cache/buildx-cache},mode=max
   labels:
     org.opencontainers.image.source: "https://github.com/Cdaprod/Media-Indexer-Stdlib-Prototype"
     org.opencontainers.image.vendor: "Cdaprod"

--- a/docker/compose/docker-compose.capture-daemon.yaml
+++ b/docker/compose/docker-compose.capture-daemon.yaml
@@ -8,9 +8,10 @@ x-build-common: &build-common
   args:
     BUILDKIT_INLINE_CACHE: "1"
   cache_from:
-    - type=local,src=/tmp/buildx-cache
+    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build
+    - type=local,src=${BUILDX_CACHE_SRC:-$HOME/.cache/buildx-cache}
   cache_to:
-    - type=local,dest=/tmp/buildx-cache,mode=max
+    - type=local,dest=${BUILDX_CACHE_DEST:-$HOME/.cache/buildx-cache},mode=max
   labels:
     org.opencontainers.image.source: "https://github.com/Cdaprod/Media-Indexer-Stdlib-Prototype"
     org.opencontainers.image.vendor: "Cdaprod"

--- a/docker/compose/docker-compose.discovery.yaml
+++ b/docker/compose/docker-compose.discovery.yaml
@@ -8,9 +8,10 @@ x-build-common: &build-common
   args:
     BUILDKIT_INLINE_CACHE: "1"
   cache_from:
-    - type=local,src=/tmp/buildx-cache
+    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build
+    - type=local,src=${BUILDX_CACHE_SRC:-$HOME/.cache/buildx-cache}
   cache_to:
-    - type=local,dest=/tmp/buildx-cache,mode=max
+    - type=local,dest=${BUILDX_CACHE_DEST:-$HOME/.cache/buildx-cache},mode=max
   labels:
     org.opencontainers.image.source: "https://github.com/Cdaprod/Media-Indexer-Stdlib-Prototype"
     org.opencontainers.image.vendor: "Cdaprod"

--- a/docker/compose/docker-compose.gateway.yaml
+++ b/docker/compose/docker-compose.gateway.yaml
@@ -8,9 +8,10 @@ x-build-common: &build-common
   args:
     BUILDKIT_INLINE_CACHE: "1"
   cache_from:
-    - type=local,src=/tmp/buildx-cache
+    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build
+    - type=local,src=${BUILDX_CACHE_SRC:-$HOME/.cache/buildx-cache}
   cache_to:
-    - type=local,dest=/tmp/buildx-cache,mode=max
+    - type=local,dest=${BUILDX_CACHE_DEST:-$HOME/.cache/buildx-cache},mode=max
   labels:
     org.opencontainers.image.source: "https://github.com/Cdaprod/Media-Indexer-Stdlib-Prototype"
     org.opencontainers.image.vendor: "Cdaprod"

--- a/docker/compose/docker-compose.media-api.yaml
+++ b/docker/compose/docker-compose.media-api.yaml
@@ -8,9 +8,10 @@ x-build-common: &build-common
   args:
     BUILDKIT_INLINE_CACHE: "1"
   cache_from:
-    - type=local,src=/tmp/buildx-cache
+    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build
+    - type=local,src=${BUILDX_CACHE_SRC:-$HOME/.cache/buildx-cache}
   cache_to:
-    - type=local,dest=/tmp/buildx-cache,mode=max
+    - type=local,dest=${BUILDX_CACHE_DEST:-$HOME/.cache/buildx-cache},mode=max
   labels:
     org.opencontainers.image.source: "https://github.com/Cdaprod/Media-Indexer-Stdlib-Prototype"
     org.opencontainers.image.vendor: "Cdaprod"

--- a/docker/compose/docker-compose.minio.yaml
+++ b/docker/compose/docker-compose.minio.yaml
@@ -8,9 +8,10 @@ x-build-common: &build-common
   args:
     BUILDKIT_INLINE_CACHE: "1"
   cache_from:
-    - type=local,src=/tmp/buildx-cache
+    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build
+    - type=local,src=${BUILDX_CACHE_SRC:-$HOME/.cache/buildx-cache}
   cache_to:
-    - type=local,dest=/tmp/buildx-cache,mode=max
+    - type=local,dest=${BUILDX_CACHE_DEST:-$HOME/.cache/buildx-cache},mode=max
   labels:
     org.opencontainers.image.source: "https://github.com/Cdaprod/Media-Indexer-Stdlib-Prototype"
     org.opencontainers.image.vendor: "Cdaprod"

--- a/docker/compose/docker-compose.overlay-hub.yaml
+++ b/docker/compose/docker-compose.overlay-hub.yaml
@@ -8,9 +8,10 @@ x-build-common: &build-common
   args:
     BUILDKIT_INLINE_CACHE: "1"
   cache_from:
-    - type=local,src=/tmp/buildx-cache
+    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build
+    - type=local,src=${BUILDX_CACHE_SRC:-$HOME/.cache/buildx-cache}
   cache_to:
-    - type=local,dest=/tmp/buildx-cache,mode=max
+    - type=local,dest=${BUILDX_CACHE_DEST:-$HOME/.cache/buildx-cache},mode=max
   labels:
     org.opencontainers.image.source: "https://github.com/Cdaprod/Media-Indexer-Stdlib-Prototype"
     org.opencontainers.image.vendor: "Cdaprod"

--- a/docker/compose/docker-compose.rabbitmq.yaml
+++ b/docker/compose/docker-compose.rabbitmq.yaml
@@ -8,9 +8,10 @@ x-build-common: &build-common
   args:
     BUILDKIT_INLINE_CACHE: "1"
   cache_from:
-    - type=local,src=/tmp/buildx-cache
+    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build
+    - type=local,src=${BUILDX_CACHE_SRC:-$HOME/.cache/buildx-cache}
   cache_to:
-    - type=local,dest=/tmp/buildx-cache,mode=max
+    - type=local,dest=${BUILDX_CACHE_DEST:-$HOME/.cache/buildx-cache},mode=max
   labels:
     org.opencontainers.image.source: "https://github.com/Cdaprod/Media-Indexer-Stdlib-Prototype"
     org.opencontainers.image.vendor: "Cdaprod"

--- a/docker/compose/docker-compose.runner.yaml
+++ b/docker/compose/docker-compose.runner.yaml
@@ -8,9 +8,10 @@ x-build-common: &build-common
   args:
     BUILDKIT_INLINE_CACHE: "1"
   cache_from:
-    - type=local,src=/tmp/buildx-cache
+    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build
+    - type=local,src=${BUILDX_CACHE_SRC:-$HOME/.cache/buildx-cache}
   cache_to:
-    - type=local,dest=/tmp/buildx-cache,mode=max
+    - type=local,dest=${BUILDX_CACHE_DEST:-$HOME/.cache/buildx-cache},mode=max
   labels:
     org.opencontainers.image.source: "https://github.com/Cdaprod/Media-Indexer-Stdlib-Prototype"
     org.opencontainers.image.vendor: "Cdaprod"

--- a/docker/compose/docker-compose.supervisor.yaml
+++ b/docker/compose/docker-compose.supervisor.yaml
@@ -8,9 +8,10 @@ x-build-common: &build-common
   args:
     BUILDKIT_INLINE_CACHE: "1"
   cache_from:
-    - type=local,src=/tmp/buildx-cache
+    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build
+    - type=local,src=${BUILDX_CACHE_SRC:-$HOME/.cache/buildx-cache}
   cache_to:
-    - type=local,dest=/tmp/buildx-cache,mode=max
+    - type=local,dest=${BUILDX_CACHE_DEST:-$HOME/.cache/buildx-cache},mode=max
   labels:
     org.opencontainers.image.source: "https://github.com/Cdaprod/Media-Indexer-Stdlib-Prototype"
     org.opencontainers.image.vendor: "Cdaprod"

--- a/docker/compose/docker-compose.tenancy.yaml
+++ b/docker/compose/docker-compose.tenancy.yaml
@@ -8,9 +8,10 @@ x-build-common: &build-common
   args:
     BUILDKIT_INLINE_CACHE: "1"
   cache_from:
-    - type=local,src=/tmp/buildx-cache
+    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build
+    - type=local,src=${BUILDX_CACHE_SRC:-$HOME/.cache/buildx-cache}
   cache_to:
-    - type=local,dest=/tmp/buildx-cache,mode=max
+    - type=local,dest=${BUILDX_CACHE_DEST:-$HOME/.cache/buildx-cache},mode=max
   labels:
     org.opencontainers.image.source: "https://github.com/Cdaprod/Media-Indexer-Stdlib-Prototype"
     org.opencontainers.image.vendor: "Cdaprod"

--- a/docker/compose/docker-compose.touch.yaml
+++ b/docker/compose/docker-compose.touch.yaml
@@ -8,9 +8,10 @@ x-build-common: &build-common
   args:
     BUILDKIT_INLINE_CACHE: "1"
   cache_from:
-    - type=local,src=/tmp/buildx-cache
+    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build
+    - type=local,src=${BUILDX_CACHE_SRC:-$HOME/.cache/buildx-cache}
   cache_to:
-    - type=local,dest=/tmp/buildx-cache,mode=max
+    - type=local,dest=${BUILDX_CACHE_DEST:-$HOME/.cache/buildx-cache},mode=max
   labels:
     org.opencontainers.image.source: "https://github.com/Cdaprod/Media-Indexer-Stdlib-Prototype"
     org.opencontainers.image.vendor: "Cdaprod"

--- a/docker/compose/docker-compose.video-api.yaml
+++ b/docker/compose/docker-compose.video-api.yaml
@@ -9,9 +9,10 @@ x-build-common: &build-common
   args:
     BUILDKIT_INLINE_CACHE: "1"
   cache_from:
-    - type=local,src=/tmp/buildx-cache
+    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build
+    - type=local,src=${BUILDX_CACHE_SRC:-$HOME/.cache/buildx-cache}
   cache_to:
-    - type=local,dest=/tmp/buildx-cache,mode=max
+    - type=local,dest=${BUILDX_CACHE_DEST:-$HOME/.cache/buildx-cache},mode=max
   labels:
     org.opencontainers.image.source: "https://github.com/Cdaprod/Media-Indexer-Stdlib-Prototype"
     org.opencontainers.image.vendor: "Cdaprod"

--- a/docker/compose/docker-compose.video-web.yaml
+++ b/docker/compose/docker-compose.video-web.yaml
@@ -9,9 +9,10 @@ x-build-common: &build-common
   args:
     BUILDKIT_INLINE_CACHE: "1"
   cache_from:
-    - type=local,src=/tmp/buildx-cache
+    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build
+    - type=local,src=${BUILDX_CACHE_SRC:-$HOME/.cache/buildx-cache}
   cache_to:
-    - type=local,dest=/tmp/buildx-cache,mode=max
+    - type=local,dest=${BUILDX_CACHE_DEST:-$HOME/.cache/buildx-cache},mode=max
   labels:
     org.opencontainers.image.source: "https://github.com/Cdaprod/Media-Indexer-Stdlib-Prototype"
     org.opencontainers.image.vendor: "Cdaprod"

--- a/docker/compose/docker-compose.web-site.yaml
+++ b/docker/compose/docker-compose.web-site.yaml
@@ -9,9 +9,10 @@ x-build-common: &build-common
   args:
     BUILDKIT_INLINE_CACHE: "1"
   cache_from:
-    - type=local,src=/tmp/buildx-cache
+    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build
+    - type=local,src=${BUILDX_CACHE_SRC:-$HOME/.cache/buildx-cache}
   cache_to:
-    - type=local,dest=/tmp/buildx-cache,mode=max
+    - type=local,dest=${BUILDX_CACHE_DEST:-$HOME/.cache/buildx-cache},mode=max
   labels:
     org.opencontainers.image.source: "https://github.com/Cdaprod/Media-Indexer-Stdlib-Prototype"
     org.opencontainers.image.vendor: "Cdaprod"

--- a/host/services/camera-proxy/Dockerfile
+++ b/host/services/camera-proxy/Dockerfile
@@ -38,16 +38,23 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 FROM node:20-alpine AS viewer-builder
 WORKDIR /app
 
-# build reusable player package
+# copy packages used by proxy-viewer
 COPY docker/packages/player/ ./packages/player/
+COPY docker/packages/design-system/ ./packages/design-system/
+COPY docker/packages/stream-registry/ ./packages/stream-registry/
+
+# build shared packages first
 RUN --mount=type=cache,target=/root/.npm \
     sh -ceu '\
       cd packages/player; \
       npm ci || npm install; \
+      npm run build; \
+      cd ../design-system; \
+      npm ci || npm install; \
       npm run build \
     '
 
-# build proxy-viewer depending on player
+# build proxy-viewer depending on local packages
 COPY docker/proxy-viewer/ ./proxy-viewer/
 RUN --mount=type=cache,target=/root/.npm \
     sh -ceu '\


### PR DESCRIPTION
Milestone: 🧬 Feature Development
Scope: docker,camera-proxy
Linked Issues: N/A

## Summary
- centralize BuildKit cache config across compose files
- include design system and stream registry when building camera-proxy viewer
- document BuildKit cache defaults and how to avoid manual env exports

## Testing
- `npm test` in docker/packages/design-system
- `docker compose -f docker-compose.yaml config` *(command not found)*
- `npm run build` in docker/proxy-viewer` *(Failed to resolve entry for @thatdamtoolbox/player)*


------
https://chatgpt.com/codex/tasks/task_e_68a8c81989208326a6b4e9db435330c1