### PR TITLE
fix: lock build cache and streamline viewer build

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,7 +14,7 @@ x-build-common: &build-common
     - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build
     - type=local,src=${BUILDX_CACHE_SRC:-$HOME/.cache/buildx-cache}
   cache_to:
-    - type=local,dest=${BUILDX_CACHE_DEST:-$HOME/.cache/buildx-cache},mode=max
+    - type=local,dest=${BUILDX_CACHE_DEST:-$HOME/.cache/buildx-cache},mode=max,sharing=locked
   labels:
     org.opencontainers.image.source: "https://github.com/Cdaprod/Media-Indexer-Stdlib-Prototype"
     org.opencontainers.image.vendor: "Cdaprod"

--- a/docker/README.md
+++ b/docker/README.md
@@ -132,6 +132,8 @@ Local development images use an environment-driven tag so builds stay consistent
 - **Mount the repo root** into your container (`volumes: - ../../:/app`) and add `--reload` to the API command for instant feedback.
 - **Keep dotenv files** (`.env`, `.env.local`) inside `docker/compose/` so they’re easy to share but stay out of the image build context.
 - **Use BuildKit’s inline cache** ⇢ `docker buildx build --cache-to type=inline` ⇢ lightning-fast rebuilds when iterating on one service.
+- **Shared build cache** – compose files pull from `ghcr.io/cdaprod/thatdamtoolbox-cache:build` and default to `${BUILDX_CACHE_DEST:-$HOME/.cache/buildx-cache}`; override `BUILDX_CACHE_SRC` or `BUILDX_CACHE_DEST` as needed.
+- **Enable BuildKit once** – add `{ "features": { "buildkit": true } }` to `~/.docker/config.json` so you don't have to export `DOCKER_BUILDKIT=1` every run.
 
 -----
 

--- a/docker/compose/docker-compose.api-gateway.yaml
+++ b/docker/compose/docker-compose.api-gateway.yaml
@@ -8,9 +8,10 @@ x-build-common: &build-common
   args:
     BUILDKIT_INLINE_CACHE: "1"
   cache_from:
-    - type=local,src=/tmp/buildx-cache
+    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build
+    - type=local,src=${BUILDX_CACHE_SRC:-$HOME/.cache/buildx-cache}
   cache_to:
-    - type=local,dest=/tmp/buildx-cache,mode=max
+    - type=local,dest=${BUILDX_CACHE_DEST:-$HOME/.cache/buildx-cache},mode=max,sharing=locked
   labels:
     org.opencontainers.image.source: "https://github.com/Cdaprod/Media-Indexer-Stdlib-Prototype"
     org.opencontainers.image.vendor: "Cdaprod"

--- a/docker/compose/docker-compose.auth-auth0.yaml
+++ b/docker/compose/docker-compose.auth-auth0.yaml
@@ -8,9 +8,10 @@ x-build-common: &build-common
   args:
     BUILDKIT_INLINE_CACHE: "1"
   cache_from:
-    - type=local,src=/tmp/buildx-cache
+    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build
+    - type=local,src=${BUILDX_CACHE_SRC:-$HOME/.cache/buildx-cache}
   cache_to:
-    - type=local,dest=/tmp/buildx-cache,mode=max
+    - type=local,dest=${BUILDX_CACHE_DEST:-$HOME/.cache/buildx-cache},mode=max,sharing=locked
   labels:
     org.opencontainers.image.source: "https://github.com/Cdaprod/Media-Indexer-Stdlib-Prototype"
     org.opencontainers.image.vendor: "Cdaprod"

--- a/docker/compose/docker-compose.auth-keycloak.yaml
+++ b/docker/compose/docker-compose.auth-keycloak.yaml
@@ -8,9 +8,10 @@ x-build-common: &build-common
   args:
     BUILDKIT_INLINE_CACHE: "1"
   cache_from:
-    - type=local,src=/tmp/buildx-cache
+    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build
+    - type=local,src=${BUILDX_CACHE_SRC:-$HOME/.cache/buildx-cache}
   cache_to:
-    - type=local,dest=/tmp/buildx-cache,mode=max
+    - type=local,dest=${BUILDX_CACHE_DEST:-$HOME/.cache/buildx-cache},mode=max,sharing=locked
   labels:
     org.opencontainers.image.source: "https://github.com/Cdaprod/Media-Indexer-Stdlib-Prototype"
     org.opencontainers.image.vendor: "Cdaprod"

--- a/docker/compose/docker-compose.camera-proxy.yaml
+++ b/docker/compose/docker-compose.camera-proxy.yaml
@@ -8,9 +8,10 @@ x-build-common: &build-common
   args:
     BUILDKIT_INLINE_CACHE: "1"
   cache_from:
-    - type=local,src=/tmp/buildx-cache
+    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build
+    - type=local,src=${BUILDX_CACHE_SRC:-$HOME/.cache/buildx-cache}
   cache_to:
-    - type=local,dest=/tmp/buildx-cache,mode=max
+    - type=local,dest=${BUILDX_CACHE_DEST:-$HOME/.cache/buildx-cache},mode=max,sharing=locked
   labels:
     org.opencontainers.image.source: "https://github.com/Cdaprod/Media-Indexer-Stdlib-Prototype"
     org.opencontainers.image.vendor: "Cdaprod"

--- a/docker/compose/docker-compose.capture-daemon.yaml
+++ b/docker/compose/docker-compose.capture-daemon.yaml
@@ -8,9 +8,10 @@ x-build-common: &build-common
   args:
     BUILDKIT_INLINE_CACHE: "1"
   cache_from:
-    - type=local,src=/tmp/buildx-cache
+    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build
+    - type=local,src=${BUILDX_CACHE_SRC:-$HOME/.cache/buildx-cache}
   cache_to:
-    - type=local,dest=/tmp/buildx-cache,mode=max
+    - type=local,dest=${BUILDX_CACHE_DEST:-$HOME/.cache/buildx-cache},mode=max,sharing=locked
   labels:
     org.opencontainers.image.source: "https://github.com/Cdaprod/Media-Indexer-Stdlib-Prototype"
     org.opencontainers.image.vendor: "Cdaprod"

--- a/docker/compose/docker-compose.discovery.yaml
+++ b/docker/compose/docker-compose.discovery.yaml
@@ -8,9 +8,10 @@ x-build-common: &build-common
   args:
     BUILDKIT_INLINE_CACHE: "1"
   cache_from:
-    - type=local,src=/tmp/buildx-cache
+    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build
+    - type=local,src=${BUILDX_CACHE_SRC:-$HOME/.cache/buildx-cache}
   cache_to:
-    - type=local,dest=/tmp/buildx-cache,mode=max
+    - type=local,dest=${BUILDX_CACHE_DEST:-$HOME/.cache/buildx-cache},mode=max,sharing=locked
   labels:
     org.opencontainers.image.source: "https://github.com/Cdaprod/Media-Indexer-Stdlib-Prototype"
     org.opencontainers.image.vendor: "Cdaprod"

--- a/docker/compose/docker-compose.gateway.yaml
+++ b/docker/compose/docker-compose.gateway.yaml
@@ -8,9 +8,10 @@ x-build-common: &build-common
   args:
     BUILDKIT_INLINE_CACHE: "1"
   cache_from:
-    - type=local,src=/tmp/buildx-cache
+    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build
+    - type=local,src=${BUILDX_CACHE_SRC:-$HOME/.cache/buildx-cache}
   cache_to:
-    - type=local,dest=/tmp/buildx-cache,mode=max
+    - type=local,dest=${BUILDX_CACHE_DEST:-$HOME/.cache/buildx-cache},mode=max,sharing=locked
   labels:
     org.opencontainers.image.source: "https://github.com/Cdaprod/Media-Indexer-Stdlib-Prototype"
     org.opencontainers.image.vendor: "Cdaprod"

--- a/docker/compose/docker-compose.media-api.yaml
+++ b/docker/compose/docker-compose.media-api.yaml
@@ -8,9 +8,10 @@ x-build-common: &build-common
   args:
     BUILDKIT_INLINE_CACHE: "1"
   cache_from:
-    - type=local,src=/tmp/buildx-cache
+    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build
+    - type=local,src=${BUILDX_CACHE_SRC:-$HOME/.cache/buildx-cache}
   cache_to:
-    - type=local,dest=/tmp/buildx-cache,mode=max
+    - type=local,dest=${BUILDX_CACHE_DEST:-$HOME/.cache/buildx-cache},mode=max,sharing=locked
   labels:
     org.opencontainers.image.source: "https://github.com/Cdaprod/Media-Indexer-Stdlib-Prototype"
     org.opencontainers.image.vendor: "Cdaprod"

--- a/docker/compose/docker-compose.minio.yaml
+++ b/docker/compose/docker-compose.minio.yaml
@@ -8,9 +8,10 @@ x-build-common: &build-common
   args:
     BUILDKIT_INLINE_CACHE: "1"
   cache_from:
-    - type=local,src=/tmp/buildx-cache
+    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build
+    - type=local,src=${BUILDX_CACHE_SRC:-$HOME/.cache/buildx-cache}
   cache_to:
-    - type=local,dest=/tmp/buildx-cache,mode=max
+    - type=local,dest=${BUILDX_CACHE_DEST:-$HOME/.cache/buildx-cache},mode=max,sharing=locked
   labels:
     org.opencontainers.image.source: "https://github.com/Cdaprod/Media-Indexer-Stdlib-Prototype"
     org.opencontainers.image.vendor: "Cdaprod"

--- a/docker/compose/docker-compose.overlay-hub.yaml
+++ b/docker/compose/docker-compose.overlay-hub.yaml
@@ -8,9 +8,10 @@ x-build-common: &build-common
   args:
     BUILDKIT_INLINE_CACHE: "1"
   cache_from:
-    - type=local,src=/tmp/buildx-cache
+    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build
+    - type=local,src=${BUILDX_CACHE_SRC:-$HOME/.cache/buildx-cache}
   cache_to:
-    - type=local,dest=/tmp/buildx-cache,mode=max
+    - type=local,dest=${BUILDX_CACHE_DEST:-$HOME/.cache/buildx-cache},mode=max,sharing=locked
   labels:
     org.opencontainers.image.source: "https://github.com/Cdaprod/Media-Indexer-Stdlib-Prototype"
     org.opencontainers.image.vendor: "Cdaprod"

--- a/docker/compose/docker-compose.rabbitmq.yaml
+++ b/docker/compose/docker-compose.rabbitmq.yaml
@@ -8,9 +8,10 @@ x-build-common: &build-common
   args:
     BUILDKIT_INLINE_CACHE: "1"
   cache_from:
-    - type=local,src=/tmp/buildx-cache
+    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build
+    - type=local,src=${BUILDX_CACHE_SRC:-$HOME/.cache/buildx-cache}
   cache_to:
-    - type=local,dest=/tmp/buildx-cache,mode=max
+    - type=local,dest=${BUILDX_CACHE_DEST:-$HOME/.cache/buildx-cache},mode=max,sharing=locked
   labels:
     org.opencontainers.image.source: "https://github.com/Cdaprod/Media-Indexer-Stdlib-Prototype"
     org.opencontainers.image.vendor: "Cdaprod"

--- a/docker/compose/docker-compose.runner.yaml
+++ b/docker/compose/docker-compose.runner.yaml
@@ -8,9 +8,10 @@ x-build-common: &build-common
   args:
     BUILDKIT_INLINE_CACHE: "1"
   cache_from:
-    - type=local,src=/tmp/buildx-cache
+    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build
+    - type=local,src=${BUILDX_CACHE_SRC:-$HOME/.cache/buildx-cache}
   cache_to:
-    - type=local,dest=/tmp/buildx-cache,mode=max
+    - type=local,dest=${BUILDX_CACHE_DEST:-$HOME/.cache/buildx-cache},mode=max,sharing=locked
   labels:
     org.opencontainers.image.source: "https://github.com/Cdaprod/Media-Indexer-Stdlib-Prototype"
     org.opencontainers.image.vendor: "Cdaprod"

--- a/docker/compose/docker-compose.supervisor.yaml
+++ b/docker/compose/docker-compose.supervisor.yaml
@@ -8,9 +8,10 @@ x-build-common: &build-common
   args:
     BUILDKIT_INLINE_CACHE: "1"
   cache_from:
-    - type=local,src=/tmp/buildx-cache
+    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build
+    - type=local,src=${BUILDX_CACHE_SRC:-$HOME/.cache/buildx-cache}
   cache_to:
-    - type=local,dest=/tmp/buildx-cache,mode=max
+    - type=local,dest=${BUILDX_CACHE_DEST:-$HOME/.cache/buildx-cache},mode=max,sharing=locked
   labels:
     org.opencontainers.image.source: "https://github.com/Cdaprod/Media-Indexer-Stdlib-Prototype"
     org.opencontainers.image.vendor: "Cdaprod"

--- a/docker/compose/docker-compose.tenancy.yaml
+++ b/docker/compose/docker-compose.tenancy.yaml
@@ -8,9 +8,10 @@ x-build-common: &build-common
   args:
     BUILDKIT_INLINE_CACHE: "1"
   cache_from:
-    - type=local,src=/tmp/buildx-cache
+    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build
+    - type=local,src=${BUILDX_CACHE_SRC:-$HOME/.cache/buildx-cache}
   cache_to:
-    - type=local,dest=/tmp/buildx-cache,mode=max
+    - type=local,dest=${BUILDX_CACHE_DEST:-$HOME/.cache/buildx-cache},mode=max,sharing=locked
   labels:
     org.opencontainers.image.source: "https://github.com/Cdaprod/Media-Indexer-Stdlib-Prototype"
     org.opencontainers.image.vendor: "Cdaprod"

--- a/docker/compose/docker-compose.touch.yaml
+++ b/docker/compose/docker-compose.touch.yaml
@@ -8,9 +8,10 @@ x-build-common: &build-common
   args:
     BUILDKIT_INLINE_CACHE: "1"
   cache_from:
-    - type=local,src=/tmp/buildx-cache
+    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build
+    - type=local,src=${BUILDX_CACHE_SRC:-$HOME/.cache/buildx-cache}
   cache_to:
-    - type=local,dest=/tmp/buildx-cache,mode=max
+    - type=local,dest=${BUILDX_CACHE_DEST:-$HOME/.cache/buildx-cache},mode=max,sharing=locked
   labels:
     org.opencontainers.image.source: "https://github.com/Cdaprod/Media-Indexer-Stdlib-Prototype"
     org.opencontainers.image.vendor: "Cdaprod"

--- a/docker/compose/docker-compose.video-api.yaml
+++ b/docker/compose/docker-compose.video-api.yaml
@@ -9,9 +9,10 @@ x-build-common: &build-common
   args:
     BUILDKIT_INLINE_CACHE: "1"
   cache_from:
-    - type=local,src=/tmp/buildx-cache
+    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build
+    - type=local,src=${BUILDX_CACHE_SRC:-$HOME/.cache/buildx-cache}
   cache_to:
-    - type=local,dest=/tmp/buildx-cache,mode=max
+    - type=local,dest=${BUILDX_CACHE_DEST:-$HOME/.cache/buildx-cache},mode=max,sharing=locked
   labels:
     org.opencontainers.image.source: "https://github.com/Cdaprod/Media-Indexer-Stdlib-Prototype"
     org.opencontainers.image.vendor: "Cdaprod"

--- a/docker/compose/docker-compose.video-web.yaml
+++ b/docker/compose/docker-compose.video-web.yaml
@@ -9,9 +9,10 @@ x-build-common: &build-common
   args:
     BUILDKIT_INLINE_CACHE: "1"
   cache_from:
-    - type=local,src=/tmp/buildx-cache
+    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build
+    - type=local,src=${BUILDX_CACHE_SRC:-$HOME/.cache/buildx-cache}
   cache_to:
-    - type=local,dest=/tmp/buildx-cache,mode=max
+    - type=local,dest=${BUILDX_CACHE_DEST:-$HOME/.cache/buildx-cache},mode=max,sharing=locked
   labels:
     org.opencontainers.image.source: "https://github.com/Cdaprod/Media-Indexer-Stdlib-Prototype"
     org.opencontainers.image.vendor: "Cdaprod"

--- a/docker/compose/docker-compose.web-site.yaml
+++ b/docker/compose/docker-compose.web-site.yaml
@@ -9,9 +9,10 @@ x-build-common: &build-common
   args:
     BUILDKIT_INLINE_CACHE: "1"
   cache_from:
-    - type=local,src=/tmp/buildx-cache
+    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build
+    - type=local,src=${BUILDX_CACHE_SRC:-$HOME/.cache/buildx-cache}
   cache_to:
-    - type=local,dest=/tmp/buildx-cache,mode=max
+    - type=local,dest=${BUILDX_CACHE_DEST:-$HOME/.cache/buildx-cache},mode=max,sharing=locked
   labels:
     org.opencontainers.image.source: "https://github.com/Cdaprod/Media-Indexer-Stdlib-Prototype"
     org.opencontainers.image.vendor: "Cdaprod"

--- a/host/services/camera-proxy/Dockerfile
+++ b/host/services/camera-proxy/Dockerfile
@@ -38,23 +38,18 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 FROM node:20-alpine AS viewer-builder
 WORKDIR /app
 
-# build reusable player package
+# copy packages used by proxy-viewer
 COPY docker/packages/player/ ./packages/player/
-RUN --mount=type=cache,target=/root/.npm \
-    sh -ceu '\
-      cd packages/player; \
-      npm ci || npm install; \
-      npm run build \
-    '
-
-# build proxy-viewer depending on player
+COPY docker/packages/design-system/ ./packages/design-system/
+COPY docker/packages/stream-registry/ ./packages/stream-registry/
 COPY docker/proxy-viewer/ ./proxy-viewer/
+
+# install and build local packages then bundle the viewer
 RUN --mount=type=cache,target=/root/.npm \
-    sh -ceu '\
-      cd proxy-viewer; \
-      npm ci || npm install; \
-      npm run build \
-    '
+    npm --prefix packages/player install && npm --prefix packages/player run build && \
+    npm --prefix packages/design-system install && npm --prefix packages/design-system run build && \
+    npm --prefix packages/stream-registry install && \
+    npm --prefix proxy-viewer install && npm --prefix proxy-viewer run build
 
 # ── runtime (needs ffmpeg, v4l2 utils for device probing)
 FROM alpine:3.20


### PR DESCRIPTION
Milestone: 🧬 Feature Development
Scope: docker,camera-proxy
Linked Issues: N/A

## Summary
- lock local BuildKit cache to avoid concurrent export failures
- install and build viewer packages in one step for camera-proxy

## Testing
- `npm test` in docker/packages/design-system
- `go test ./...` in host/services/camera-proxy
- `npm run build` in docker/proxy-viewer
- `docker compose -f docker-compose.yaml config` *(command not found)*

## Checklist
- [ ] Code is self-contained and idempotent.
- [ ] No unnecessary new files or external dependencies.
- [ ] Tests added or updated as appropriate.
- [ ] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_68a8c81989208326a6b4e9db435330c1