### PR TITLE
fix: tolerate missing build cache

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,7 +11,7 @@ x-build-common: &build-common
   args:
     BUILDKIT_INLINE_CACHE: "1"
   cache_from:
-    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build
+    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build,ignore-error=true
   labels:
     org.opencontainers.image.source: "https://github.com/Cdaprod/Media-Indexer-Stdlib-Prototype"
     org.opencontainers.image.vendor: "Cdaprod"

--- a/docker/README.md
+++ b/docker/README.md
@@ -132,7 +132,7 @@ Local development images use an environment-driven tag so builds stay consistent
 - **Mount the repo root** into your container (`volumes: - ../../:/app`) and add `--reload` to the API command for instant feedback.
 - **Keep dotenv files** (`.env`, `.env.local`) inside `docker/compose/` so they’re easy to share but stay out of the image build context.
 - **Use BuildKit’s inline cache** ⇢ `docker buildx build --cache-to type=inline` ⇢ lightning-fast rebuilds when iterating on one service.
-- **Shared build cache** – compose files pull from `ghcr.io/cdaprod/thatdamtoolbox-cache:build`; BuildKit daemon persists its cache volume automatically.
+- **Shared build cache** – compose files pull from `ghcr.io/cdaprod/thatdamtoolbox-cache:build` with `ignore-error=true` so builds proceed even if the cache is missing; BuildKit daemon persists its cache volume automatically.
 - **Enable BuildKit once** – add `{ "features": { "buildkit": true } }` to `~/.docker/config.json` so you don't have to export `DOCKER_BUILDKIT=1` every run.
 
 -----

--- a/docker/compose/docker-compose.api-gateway.yaml
+++ b/docker/compose/docker-compose.api-gateway.yaml
@@ -8,7 +8,7 @@ x-build-common: &build-common
   args:
     BUILDKIT_INLINE_CACHE: "1"
   cache_from:
-    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build
+    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build,ignore-error=true
   labels:
     org.opencontainers.image.source: "https://github.com/Cdaprod/Media-Indexer-Stdlib-Prototype"
     org.opencontainers.image.vendor: "Cdaprod"

--- a/docker/compose/docker-compose.auth-auth0.yaml
+++ b/docker/compose/docker-compose.auth-auth0.yaml
@@ -8,7 +8,7 @@ x-build-common: &build-common
   args:
     BUILDKIT_INLINE_CACHE: "1"
   cache_from:
-    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build
+    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build,ignore-error=true
   labels:
     org.opencontainers.image.source: "https://github.com/Cdaprod/Media-Indexer-Stdlib-Prototype"
     org.opencontainers.image.vendor: "Cdaprod"

--- a/docker/compose/docker-compose.auth-keycloak.yaml
+++ b/docker/compose/docker-compose.auth-keycloak.yaml
@@ -8,7 +8,7 @@ x-build-common: &build-common
   args:
     BUILDKIT_INLINE_CACHE: "1"
   cache_from:
-    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build
+    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build,ignore-error=true
   labels:
     org.opencontainers.image.source: "https://github.com/Cdaprod/Media-Indexer-Stdlib-Prototype"
     org.opencontainers.image.vendor: "Cdaprod"

--- a/docker/compose/docker-compose.buildkit.yaml
+++ b/docker/compose/docker-compose.buildkit.yaml
@@ -8,7 +8,7 @@ x-build-common: &build-common
   args:
     BUILDKIT_INLINE_CACHE: "1"
   cache_from:
-    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build
+    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build,ignore-error=true
   labels:
     org.opencontainers.image.source: "https://github.com/Cdaprod/Media-Indexer-Stdlib-Prototype"
     org.opencontainers.image.vendor: "Cdaprod"

--- a/docker/compose/docker-compose.camera-proxy.yaml
+++ b/docker/compose/docker-compose.camera-proxy.yaml
@@ -8,7 +8,7 @@ x-build-common: &build-common
   args:
     BUILDKIT_INLINE_CACHE: "1"
   cache_from:
-    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build
+    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build,ignore-error=true
   labels:
     org.opencontainers.image.source: "https://github.com/Cdaprod/Media-Indexer-Stdlib-Prototype"
     org.opencontainers.image.vendor: "Cdaprod"

--- a/docker/compose/docker-compose.capture-daemon.yaml
+++ b/docker/compose/docker-compose.capture-daemon.yaml
@@ -8,7 +8,7 @@ x-build-common: &build-common
   args:
     BUILDKIT_INLINE_CACHE: "1"
   cache_from:
-    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build
+    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build,ignore-error=true
   labels:
     org.opencontainers.image.source: "https://github.com/Cdaprod/Media-Indexer-Stdlib-Prototype"
     org.opencontainers.image.vendor: "Cdaprod"

--- a/docker/compose/docker-compose.discovery.yaml
+++ b/docker/compose/docker-compose.discovery.yaml
@@ -8,7 +8,7 @@ x-build-common: &build-common
   args:
     BUILDKIT_INLINE_CACHE: "1"
   cache_from:
-    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build
+    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build,ignore-error=true
   labels:
     org.opencontainers.image.source: "https://github.com/Cdaprod/Media-Indexer-Stdlib-Prototype"
     org.opencontainers.image.vendor: "Cdaprod"

--- a/docker/compose/docker-compose.gateway.yaml
+++ b/docker/compose/docker-compose.gateway.yaml
@@ -8,7 +8,7 @@ x-build-common: &build-common
   args:
     BUILDKIT_INLINE_CACHE: "1"
   cache_from:
-    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build
+    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build,ignore-error=true
   labels:
     org.opencontainers.image.source: "https://github.com/Cdaprod/Media-Indexer-Stdlib-Prototype"
     org.opencontainers.image.vendor: "Cdaprod"

--- a/docker/compose/docker-compose.media-api.yaml
+++ b/docker/compose/docker-compose.media-api.yaml
@@ -8,7 +8,7 @@ x-build-common: &build-common
   args:
     BUILDKIT_INLINE_CACHE: "1"
   cache_from:
-    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build
+    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build,ignore-error=true
   labels:
     org.opencontainers.image.source: "https://github.com/Cdaprod/Media-Indexer-Stdlib-Prototype"
     org.opencontainers.image.vendor: "Cdaprod"

--- a/docker/compose/docker-compose.minio.yaml
+++ b/docker/compose/docker-compose.minio.yaml
@@ -8,7 +8,7 @@ x-build-common: &build-common
   args:
     BUILDKIT_INLINE_CACHE: "1"
   cache_from:
-    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build
+    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build,ignore-error=true
   labels:
     org.opencontainers.image.source: "https://github.com/Cdaprod/Media-Indexer-Stdlib-Prototype"
     org.opencontainers.image.vendor: "Cdaprod"

--- a/docker/compose/docker-compose.overlay-hub.yaml
+++ b/docker/compose/docker-compose.overlay-hub.yaml
@@ -8,7 +8,7 @@ x-build-common: &build-common
   args:
     BUILDKIT_INLINE_CACHE: "1"
   cache_from:
-    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build
+    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build,ignore-error=true
   labels:
     org.opencontainers.image.source: "https://github.com/Cdaprod/Media-Indexer-Stdlib-Prototype"
     org.opencontainers.image.vendor: "Cdaprod"

--- a/docker/compose/docker-compose.rabbitmq.yaml
+++ b/docker/compose/docker-compose.rabbitmq.yaml
@@ -8,7 +8,7 @@ x-build-common: &build-common
   args:
     BUILDKIT_INLINE_CACHE: "1"
   cache_from:
-    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build
+    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build,ignore-error=true
   labels:
     org.opencontainers.image.source: "https://github.com/Cdaprod/Media-Indexer-Stdlib-Prototype"
     org.opencontainers.image.vendor: "Cdaprod"

--- a/docker/compose/docker-compose.runner.yaml
+++ b/docker/compose/docker-compose.runner.yaml
@@ -8,7 +8,7 @@ x-build-common: &build-common
   args:
     BUILDKIT_INLINE_CACHE: "1"
   cache_from:
-    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build
+    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build,ignore-error=true
   labels:
     org.opencontainers.image.source: "https://github.com/Cdaprod/Media-Indexer-Stdlib-Prototype"
     org.opencontainers.image.vendor: "Cdaprod"

--- a/docker/compose/docker-compose.supervisor.yaml
+++ b/docker/compose/docker-compose.supervisor.yaml
@@ -8,7 +8,7 @@ x-build-common: &build-common
   args:
     BUILDKIT_INLINE_CACHE: "1"
   cache_from:
-    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build
+    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build,ignore-error=true
   labels:
     org.opencontainers.image.source: "https://github.com/Cdaprod/Media-Indexer-Stdlib-Prototype"
     org.opencontainers.image.vendor: "Cdaprod"

--- a/docker/compose/docker-compose.tenancy.yaml
+++ b/docker/compose/docker-compose.tenancy.yaml
@@ -8,7 +8,7 @@ x-build-common: &build-common
   args:
     BUILDKIT_INLINE_CACHE: "1"
   cache_from:
-    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build
+    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build,ignore-error=true
   labels:
     org.opencontainers.image.source: "https://github.com/Cdaprod/Media-Indexer-Stdlib-Prototype"
     org.opencontainers.image.vendor: "Cdaprod"

--- a/docker/compose/docker-compose.touch.yaml
+++ b/docker/compose/docker-compose.touch.yaml
@@ -8,7 +8,7 @@ x-build-common: &build-common
   args:
     BUILDKIT_INLINE_CACHE: "1"
   cache_from:
-    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build
+    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build,ignore-error=true
   labels:
     org.opencontainers.image.source: "https://github.com/Cdaprod/Media-Indexer-Stdlib-Prototype"
     org.opencontainers.image.vendor: "Cdaprod"

--- a/docker/compose/docker-compose.video-api.yaml
+++ b/docker/compose/docker-compose.video-api.yaml
@@ -9,7 +9,7 @@ x-build-common: &build-common
   args:
     BUILDKIT_INLINE_CACHE: "1"
   cache_from:
-    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build
+    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build,ignore-error=true
   labels:
     org.opencontainers.image.source: "https://github.com/Cdaprod/Media-Indexer-Stdlib-Prototype"
     org.opencontainers.image.vendor: "Cdaprod"

--- a/docker/compose/docker-compose.video-web.yaml
+++ b/docker/compose/docker-compose.video-web.yaml
@@ -9,7 +9,7 @@ x-build-common: &build-common
   args:
     BUILDKIT_INLINE_CACHE: "1"
   cache_from:
-    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build
+    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build,ignore-error=true
   labels:
     org.opencontainers.image.source: "https://github.com/Cdaprod/Media-Indexer-Stdlib-Prototype"
     org.opencontainers.image.vendor: "Cdaprod"

--- a/docker/compose/docker-compose.web-site.yaml
+++ b/docker/compose/docker-compose.web-site.yaml
@@ -9,7 +9,7 @@ x-build-common: &build-common
   args:
     BUILDKIT_INLINE_CACHE: "1"
   cache_from:
-    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build
+    - type=registry,ref=ghcr.io/cdaprod/thatdamtoolbox-cache:build,ignore-error=true
   labels:
     org.opencontainers.image.source: "https://github.com/Cdaprod/Media-Indexer-Stdlib-Prototype"
     org.opencontainers.image.vendor: "Cdaprod"


### PR DESCRIPTION
Milestone: 🧬 Feature Development
Scope: docker
Linked Issues: 

## Summary
- ignore remote build cache errors so compose builds proceed when cache manifest is absent

## Testing
- `yamllint -d "{extends: default, rules: {line-length: disable, colons: disable, commas: disable, trailing-spaces: disable, document-start: disable, comments: disable, comments-indentation: disable}}" docker-compose.yaml docker/compose/docker-compose.video-api.yaml`
- `docker compose config` *(fails: command not found)*

## PR Checklist
- [ ] Code is self-contained and idempotent.
- [ ] No unnecessary new files or external dependencies.
- [ ] Tests added or updated as appropriate.
- [ ] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_68a8d6a060cc83268f33735df84b7ab2