### PR TITLE
fix(web-app): mock optional modules for tests

### DIFF
--- a/docker/web-app/package.json
+++ b/docker/web-app/package.json
@@ -14,7 +14,7 @@
     "docker:build": "docker build -t thatdamtoolbox-web-app:dev .",
     "docker:run": "docker run --rm -p 3000:3000 thatdamtoolbox-web-app:dev",
     "docker:sh": "docker run -it --rm thatdamtoolbox-web-app:dev sh",
-    "test": "rm -rf .tmp-test && tsc -p tsconfig.test.json && node --test $(find .tmp-test -name '*.test.js')"
+    "test": "rm -rf .tmp-test && tsc -p tsconfig.test.json && node --require ./src/test/test-mocks.js --test $(find .tmp-test -name '*.test.js')"
   },
   "dependencies": {
     "@headlessui/react": "^1.7.18",

--- a/docker/web-app/src/test/test-mocks.js
+++ b/docker/web-app/src/test/test-mocks.js
@@ -1,0 +1,23 @@
+/**
+ * Runtime mocks for optional frontend modules in tests.
+ *
+ * Usage:
+ *   node --require ./src/test/test-mocks.js --test <files>
+ */
+const Module = require('module');
+const originalRequire = Module.prototype.require;
+Module.prototype.require = function (id) {
+  if (id === '@mui/material') {
+    const React = require('react');
+    return new Proxy({}, {
+      get: () => (props) => React.createElement(React.Fragment, null, props && props.children)
+    });
+  }
+  if (id === 'next-auth/react') {
+    return { signIn: async () => {} };
+  }
+  if (id === 'react-devtools-core') {
+    return { connectToDevTools: () => ({}) };
+  }
+  return originalRequire.call(this, id);
+};

--- a/docker/web-app/src/types/externals.d.ts
+++ b/docker/web-app/src/types/externals.d.ts
@@ -1,0 +1,17 @@
+/**
+ * Stub type declarations for external modules used in the web app.
+ *
+ * These packages are not installed in the minimal test environment, but
+ * TypeScript needs their module definitions during compilation.
+ *
+ * Example:
+ * ```ts
+ * import { Button } from '@mui/material';
+ * ```
+ */
+declare module '@mui/material';
+declare module '@mui/icons-material';
+declare module '@emotion/react';
+declare module '@emotion/styled';
+declare module 'next-auth/react';
+

--- a/docker/web-app/tsconfig.test.json
+++ b/docker/web-app/tsconfig.test.json
@@ -5,7 +5,8 @@
     "outDir": ".tmp-test",
     "module": "commonjs",
     "target": "es2019",
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "noImplicitAny": false
   },
   "include": [
     "src/lib/__tests__/api.test.ts",
@@ -23,7 +24,8 @@
     "src/styles/__tests__/tokens.test.ts",
     "src/components/__tests__/uiUxTasks.test.ts",
     "src/lib/server/__tests__/settingsDB.test.ts",
-    "src/app/api/policy/__tests__/evaluate.test.ts"
+    "src/app/api/policy/__tests__/evaluate.test.ts",
+    "src/types/externals.d.ts"
   ],
   "exclude": []
 }


### PR DESCRIPTION
Milestone: 🧬 Feature Development
Scope: docker/web-app
Linked Issues: N/A

## Summary
- add runtime module mocks so tests run without optional packages
- relax test TypeScript config and include declaration stubs

## Testing
- `npm test`

## Checklist
- [ ] Code is self-contained and idempotent.
- [ ] No unnecessary new files or external dependencies.
- [ ] Tests added or updated as appropriate.
- [ ] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_68a8e5daf10c832694a889611742d95e