### PR TITLE
fix: share auth options for NextAuth route

### DIFF
--- a/docker/web-app/src/app/api/auth/[...nextauth]/route.ts
+++ b/docker/web-app/src/app/api/auth/[...nextauth]/route.ts
@@ -7,27 +7,8 @@
  * Environment variables:
  *   GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, NEXTAUTH_URL, NEXTAUTH_SECRET
  */
-import NextAuth, { type NextAuthOptions } from "next-auth";
-import Google from "next-auth/providers/google";
-
-export const authOptions: NextAuthOptions = {
-  providers: [
-    Google({
-      clientId: process.env.GOOGLE_CLIENT_ID!,
-      clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
-    }),
-  ],
-  session: { strategy: "jwt" },
-  callbacks: {
-    async jwt({ token }) {
-      return token;
-    },
-    async session({ session, token }) {
-      (session as any).tenants = (token as any).tenants ?? [];
-      return session;
-    },
-  },
-};
+import NextAuth from "next-auth";
+import { authOptions } from "@/lib/auth";
 
 const handler = NextAuth(authOptions);
 export { handler as GET, handler as POST };

--- a/docker/web-app/src/lib/auth.test.ts
+++ b/docker/web-app/src/lib/auth.test.ts
@@ -1,0 +1,15 @@
+/**
+ * Tests for NextAuth configuration.
+ *
+ * Example:
+ *   node --test src/lib/auth.test.ts
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { authOptions } from './auth';
+
+test('authOptions uses Google provider and JWT sessions', () => {
+  assert.equal(authOptions.session?.strategy, 'jwt');
+  const provider = authOptions.providers?.[0] as any;
+  assert(provider && provider.id === 'google');
+});

--- a/docker/web-app/src/lib/auth.ts
+++ b/docker/web-app/src/lib/auth.ts
@@ -1,0 +1,28 @@
+/**
+ * Shared NextAuth configuration.
+ *
+ * Example:
+ *   import { authOptions } from "@/lib/auth";
+ *   const session = await getServerSession(authOptions);
+ */
+import { type NextAuthOptions } from "next-auth";
+import Google from "next-auth/providers/google";
+
+export const authOptions: NextAuthOptions = {
+  providers: [
+    Google({
+      clientId: process.env.GOOGLE_CLIENT_ID!,
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+    }),
+  ],
+  session: { strategy: "jwt" },
+  callbacks: {
+    async jwt({ token }) {
+      return token;
+    },
+    async session({ session, token }) {
+      (session as any).tenants = (token as any).tenants ?? [];
+      return session;
+    },
+  },
+};

--- a/docker/web-app/src/lib/tenancy/server.ts
+++ b/docker/web-app/src/lib/tenancy/server.ts
@@ -7,7 +7,7 @@
 import "server-only";
 import { headers } from "next/headers";
 import { getServerSession } from "next-auth";
-import { authOptions } from "@/app/api/auth/[...nextauth]/route";
+import { authOptions } from "@/lib/auth";
 
 export async function requireTenant() {
   const slug = headers().get("x-tenant-slug");

--- a/docker/web-app/tsconfig.test.json
+++ b/docker/web-app/tsconfig.test.json
@@ -25,7 +25,8 @@
     "src/components/__tests__/uiUxTasks.test.ts",
     "src/lib/server/__tests__/settingsDB.test.ts",
     "src/app/api/policy/__tests__/evaluate.test.ts",
-    "src/types/externals.d.ts"
+    "src/types/externals.d.ts",
+    "src/lib/auth.test.ts"
   ],
   "exclude": []
 }


### PR DESCRIPTION
Milestone: 🧬 Feature Development
Scope: docker/web-app
Linked Issues: none

## Summary
- extract shared NextAuth options to dedicated module
- update auth route and tenancy helper to use shared config
- add basic test ensuring Google provider and JWT session

## Testing
- `npm test`
- `npm run build` *(fails: Type 'SignupPageProps | undefined' does not satisfy the constraint 'PageProps')*

## Checklist
- [x] Code is self-contained and idempotent.
- [x] No unnecessary new files or external dependencies.
- [x] Tests added or updated as appropriate.
- [x] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_68a8f0cae8cc83268b29db8e50bbc8f0