### PR TITLE
fix(web-app): embed standalone react devtools

### DIFF
--- a/docker/web-app/package.json
+++ b/docker/web-app/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "dev": "node start.js dev",
+    "dev": "NEXT_PUBLIC_ENABLE_REACT_DEVTOOLS=1 node start.js dev",
     "build": "next build",
     "start": "NODE_ENV=production node start.js start",
     "export": "next export -o build",

--- a/docker/web-app/src/providers/AppProviders.tsx
+++ b/docker/web-app/src/providers/AppProviders.tsx
@@ -31,16 +31,37 @@ const CaptureProvider = dynamic(
 
 export default function AppProviders({ children }: { children: ReactNode }) {
   useEffect(() => {
-    if (process.env.NODE_ENV === 'development') {
-      import('react-devtools-core')
-        .then(({ connectToDevTools }) =>
-          connectToDevTools({ host: window.location.hostname, port: 8097 })
-        )
-        .catch(() => {
-          // Ignore devtools connection errors in development.
-        });
+    const DEV = process.env.NODE_ENV === 'development'
+    const ENABLED = process.env.NEXT_PUBLIC_ENABLE_REACT_DEVTOOLS !== '0'
+
+    if (!DEV || !ENABLED) return
+    if (typeof window === 'undefined') return
+    // @ts-ignore – Next sets this in edge runtimes
+    if (typeof (globalThis as any).EdgeRuntime !== 'undefined') return
+
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const DevTools = require('react-devtools-core/standalone')
+
+    let el = document.getElementById('react-devtools')
+    if (!el) {
+      el = document.createElement('div')
+      el.id = 'react-devtools'
+      Object.assign(el.style, {
+        position: 'fixed',
+        left: '0',
+        right: '0',
+        bottom: '0',
+        height: '38vh',
+        zIndex: '2147483647',
+        background: '#111',
+        borderTop: '1px solid rgba(255,255,255,0.08)',
+      } as CSSStyleDeclaration)
+      document.body.appendChild(el)
     }
-  }, []);
+
+    const port = Number(process.env.NEXT_PUBLIC_REACT_DEVTOOLS_PORT ?? 8097)
+    DevTools.setContentDOMNode(el).startServer(port)
+  }, [])
 
   return (
     <QueryClientProvider client={qc}>
@@ -61,6 +82,8 @@ export default function AppProviders({ children }: { children: ReactNode }) {
         </SidebarProvider>
       </AuthProvider>
       <ReactQueryDevtools initialIsOpen={false} />
+      {/* container for the embedded devtools UI */}
+      <div id="react-devtools" />
     </QueryClientProvider>
   )
 }

--- a/docker/web-app/src/react-devtools-core.d.ts
+++ b/docker/web-app/src/react-devtools-core.d.ts
@@ -1,1 +1,10 @@
 declare module 'react-devtools-core';
+
+declare module 'react-devtools-core/standalone' {
+  interface DevToolsStandalone {
+    setContentDOMNode(node: HTMLElement): DevToolsStandalone
+    startServer(port?: number): void
+  }
+  const DevTools: DevToolsStandalone
+  export = DevTools
+}


### PR DESCRIPTION
Milestone: 🧬 Feature Development
Scope: web-app
Linked Issues: n/a

## Summary
- mount standalone `react-devtools` panel in AppProviders and expose container
- add typings for `react-devtools-core/standalone`
- enable DevTools via `NEXT_PUBLIC_ENABLE_REACT_DEVTOOLS` in dev script

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint config)*
- `npm run type-check` *(fails: cannot find types & implicit any errors)*

## Checklist
- [x] Code is self-contained and idempotent.
- [x] No unnecessary new files or external dependencies.
- [ ] Tests added or updated as appropriate.
- [ ] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_68a8f1d49e948326b5569a1f0a03370f