### PR TITLE
fix(web-app): connect to React DevTools correctly

### DIFF
--- a/docker/web-app/src/providers/AppProviders.tsx
+++ b/docker/web-app/src/providers/AppProviders.tsx
@@ -40,27 +40,9 @@ export default function AppProviders({ children }: { children: ReactNode }) {
     if (typeof (globalThis as any).EdgeRuntime !== 'undefined') return
 
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const DevTools = require('react-devtools-core/standalone')
-
-    let el = document.getElementById('react-devtools')
-    if (!el) {
-      el = document.createElement('div')
-      el.id = 'react-devtools'
-      Object.assign(el.style, {
-        position: 'fixed',
-        left: '0',
-        right: '0',
-        bottom: '0',
-        height: '38vh',
-        zIndex: '2147483647',
-        background: '#111',
-        borderTop: '1px solid rgba(255,255,255,0.08)',
-      } as CSSStyleDeclaration)
-      document.body.appendChild(el)
-    }
-
+    const { connectToDevTools } = require('react-devtools-core')
     const port = Number(process.env.NEXT_PUBLIC_REACT_DEVTOOLS_PORT ?? 8097)
-    DevTools.setContentDOMNode(el).startServer(port)
+    connectToDevTools({ host: 'localhost', port })
   }, [])
 
   return (
@@ -82,8 +64,6 @@ export default function AppProviders({ children }: { children: ReactNode }) {
         </SidebarProvider>
       </AuthProvider>
       <ReactQueryDevtools initialIsOpen={false} />
-      {/* container for the embedded devtools UI */}
-      <div id="react-devtools" />
     </QueryClientProvider>
   )
 }

--- a/docker/web-app/src/react-devtools-core.d.ts
+++ b/docker/web-app/src/react-devtools-core.d.ts
@@ -1,10 +1,3 @@
-declare module 'react-devtools-core';
-
-declare module 'react-devtools-core/standalone' {
-  interface DevToolsStandalone {
-    setContentDOMNode(node: HTMLElement): DevToolsStandalone
-    startServer(port?: number): void
-  }
-  const DevTools: DevToolsStandalone
-  export = DevTools
+declare module 'react-devtools-core' {
+  export function connectToDevTools(options?: { host?: string; port?: number }): void;
 }

--- a/docker/web-app/start.js
+++ b/docker/web-app/start.js
@@ -3,17 +3,20 @@ const { publishServiceUp } = require('./src/lib/serviceUp.js');
 
 const mode = process.argv[2] === 'start' ? 'start' : 'dev';
 
-// Start a React DevTools server during local development so the app can
-// connect without needing a browser extension.  This is a no-op in
-// production builds.
+// Attempt to connect to a locally running React DevTools instance during
+// development.  `connectToDevTools` is a no-op if the DevTools server is not
+// running, so this block can safely fail.
 if (mode === 'dev') {
   try {
     // react-devtools-core expects a `self` global when required in Node.
     global.self = global;
-    const { startServer } = require('react-devtools-core');
-    startServer();
+    const { connectToDevTools } = require('react-devtools-core');
+    connectToDevTools({
+      host: 'localhost',
+      port: Number(process.env.NEXT_PUBLIC_REACT_DEVTOOLS_PORT ?? 8097),
+    });
   } catch (err) {
-    console.warn('react-devtools-core failed to start:', err.message);
+    console.warn('react-devtools-core failed to connect:', err.message);
   }
 }
 


### PR DESCRIPTION
Milestone: 🧬 Feature Development
Scope: web-app
Linked Issues: n/a

## Summary
- replace invalid `startServer` call with `connectToDevTools`
- simplify AppProviders to connect to a local React DevTools server when enabled

## Testing
- `npm test`

## Checklist
- [ ] Code is self-contained and idempotent.
- [ ] No unnecessary new files or external dependencies.
- [ ] Tests added or updated as appropriate.
- [ ] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_68a8f47872c48326a2c367c5805e1f83