### PR TITLE
fix(web-app): connect to React DevTools correctly

### DIFF
--- a/docker/web-app/src/lib/__tests__/startDevtools.test.ts
+++ b/docker/web-app/src/lib/__tests__/startDevtools.test.ts
@@ -1,0 +1,22 @@
+import test from 'node:test'
+import assert from 'node:assert'
+import { maybeConnectReactDevTools } from '../reactDevtools.js'
+
+// Example: node --test src/lib/__tests__/startDevtools.test.ts
+
+test('maybeConnectReactDevTools is a no-op without window', () => {
+  let warned = 0
+  const originalWarn = console.warn
+  console.warn = () => { warned++ }
+
+  const prevEnv = process.env.NEXT_PUBLIC_ENABLE_REACT_DEVTOOLS
+  process.env.NEXT_PUBLIC_ENABLE_REACT_DEVTOOLS = '1'
+  delete (globalThis as any).window
+
+  maybeConnectReactDevTools('dev')
+
+  assert.strictEqual(warned, 0)
+
+  process.env.NEXT_PUBLIC_ENABLE_REACT_DEVTOOLS = prevEnv
+  console.warn = originalWarn
+})

--- a/docker/web-app/src/lib/reactDevtools.js
+++ b/docker/web-app/src/lib/reactDevtools.js
@@ -1,0 +1,27 @@
+/**
+ * Optionally connect to a running React DevTools instance.
+ *
+ * Example:
+ *   maybeConnectReactDevTools('dev')
+ */
+function maybeConnectReactDevTools(mode) {
+  if (
+    mode !== 'dev' ||
+    process.env.NEXT_PUBLIC_ENABLE_REACT_DEVTOOLS === '0' ||
+    typeof globalThis.window === 'undefined'
+  ) {
+    return
+  }
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { connectToDevTools } = require('react-devtools-core')
+    connectToDevTools({
+      host: 'localhost',
+      port: Number(process.env.NEXT_PUBLIC_REACT_DEVTOOLS_PORT ?? 8097),
+    })
+  } catch (err) {
+    console.warn('react-devtools-core failed to connect:', err.message)
+  }
+}
+
+module.exports = { maybeConnectReactDevTools }

--- a/docker/web-app/src/providers/AppProviders.tsx
+++ b/docker/web-app/src/providers/AppProviders.tsx
@@ -40,27 +40,9 @@ export default function AppProviders({ children }: { children: ReactNode }) {
     if (typeof (globalThis as any).EdgeRuntime !== 'undefined') return
 
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const DevTools = require('react-devtools-core/standalone')
-
-    let el = document.getElementById('react-devtools')
-    if (!el) {
-      el = document.createElement('div')
-      el.id = 'react-devtools'
-      Object.assign(el.style, {
-        position: 'fixed',
-        left: '0',
-        right: '0',
-        bottom: '0',
-        height: '38vh',
-        zIndex: '2147483647',
-        background: '#111',
-        borderTop: '1px solid rgba(255,255,255,0.08)',
-      } as CSSStyleDeclaration)
-      document.body.appendChild(el)
-    }
-
+    const { connectToDevTools } = require('react-devtools-core')
     const port = Number(process.env.NEXT_PUBLIC_REACT_DEVTOOLS_PORT ?? 8097)
-    DevTools.setContentDOMNode(el).startServer(port)
+    connectToDevTools({ host: 'localhost', port })
   }, [])
 
   return (
@@ -82,8 +64,6 @@ export default function AppProviders({ children }: { children: ReactNode }) {
         </SidebarProvider>
       </AuthProvider>
       <ReactQueryDevtools initialIsOpen={false} />
-      {/* container for the embedded devtools UI */}
-      <div id="react-devtools" />
     </QueryClientProvider>
   )
 }

--- a/docker/web-app/src/react-devtools-core.d.ts
+++ b/docker/web-app/src/react-devtools-core.d.ts
@@ -1,10 +1,3 @@
-declare module 'react-devtools-core';
-
-declare module 'react-devtools-core/standalone' {
-  interface DevToolsStandalone {
-    setContentDOMNode(node: HTMLElement): DevToolsStandalone
-    startServer(port?: number): void
-  }
-  const DevTools: DevToolsStandalone
-  export = DevTools
+declare module 'react-devtools-core' {
+  export function connectToDevTools(options?: { host?: string; port?: number }): void;
 }

--- a/docker/web-app/src/test/test-mocks.js
+++ b/docker/web-app/src/test/test-mocks.js
@@ -17,6 +17,12 @@ if (process.env.NODE_ENV === 'test') {
     if (id === 'next-auth/react') {
       return { signIn: async () => {} };
     }
+    if (id === 'next-auth') {
+      return {};
+    }
+    if (id === 'next-auth/providers/google') {
+      return () => ({ id: 'google' });
+    }
     if (id === 'react-devtools-core') {
       return { connectToDevTools: () => ({}), startServer: () => {} };
     }

--- a/docker/web-app/src/types/externals.d.ts
+++ b/docker/web-app/src/types/externals.d.ts
@@ -14,4 +14,8 @@ declare module '@mui/icons-material';
 declare module '@emotion/react';
 declare module '@emotion/styled';
 declare module 'next-auth/react';
+declare module 'next-auth' {
+  export type NextAuthOptions = any;
+}
+declare module 'next-auth/providers/google';
 

--- a/docker/web-app/start.js
+++ b/docker/web-app/start.js
@@ -1,21 +1,14 @@
+// start.js - spawn Next.js dev or production server
+// Usage: node start.js [dev|start]
+// Example: NEXT_PUBLIC_ENABLE_REACT_DEVTOOLS=1 node start.js dev
 const { spawn }          = require('child_process');
 const { publishServiceUp } = require('./src/lib/serviceUp.js');
+const { maybeConnectReactDevTools } = require('./src/lib/reactDevtools.js');
 
 const mode = process.argv[2] === 'start' ? 'start' : 'dev';
 
-// Start a React DevTools server during local development so the app can
-// connect without needing a browser extension.  This is a no-op in
-// production builds.
-if (mode === 'dev') {
-  try {
-    // react-devtools-core expects a `self` global when required in Node.
-    global.self = global;
-    const { startServer } = require('react-devtools-core');
-    startServer();
-  } catch (err) {
-    console.warn('react-devtools-core failed to start:', err.message);
-  }
-}
+// Attempt to connect to React DevTools only when running in a browser context.
+maybeConnectReactDevTools(mode);
 
 const child = mode === 'start'
   ? spawn('node', ['.next/standalone/server.js'], { stdio: ['ignore', 'pipe', 'pipe'] })

--- a/docker/web-app/tsconfig.test.json
+++ b/docker/web-app/tsconfig.test.json
@@ -21,6 +21,7 @@
     "src/app/[tenant]/__tests__/settings.test.tsx",
     "src/components/__tests__/uiUxTasks.test.ts",
     "src/lib/__tests__/fitRect.test.ts",
+    "src/lib/__tests__/startDevtools.test.ts",
     "src/styles/__tests__/tokens.test.ts",
     "src/components/__tests__/uiUxTasks.test.ts",
     "src/lib/server/__tests__/settingsDB.test.ts",


### PR DESCRIPTION
Milestone: 🧬 Feature Development
Scope: web-app
Linked Issues: n/a

## Summary
- guard React DevTools connection so Node scripts skip when `window` is absent
- encapsulate DevTools wiring in a small helper and add tests
- stub `next-auth` modules to keep isolated tests passing

## Testing
- `npm test`

## Checklist
- [ ] Code is self-contained and idempotent.
- [ ] No unnecessary new files or external dependencies.
- [ ] Tests added or updated as appropriate.
- [ ] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_68a8f47872c48326a2c367c5805e1f83