### PR TITLE
fix: remove unsupported Next.js precompile flag

### DIFF
--- a/docker/web-app/README.md
+++ b/docker/web-app/README.md
@@ -39,12 +39,6 @@ Then open http://localhost:3000/signup in your browser.
   http://localhost:8097 to inspect component trees without installing a
   browser extension.
 
-## Precompiling
-
-Next.js experimental precompilation is enabled via `next.config.mjs` and requires
-Next.js `14.2` or newer. The app precompiles during `next build` to speed up App
-Router startup.
-
 ## Core Configuration Files
 
 ```

--- a/docker/web-app/next.config.mjs
+++ b/docker/web-app/next.config.mjs
@@ -8,10 +8,6 @@ const API_BASE =
 const nextConfig = {
   reactStrictMode: true,
   output: 'standalone', // produce .next/standalone
-  experimental: {
-    precompile: true,
-  },
-
   async rewrites() {
     return [
       // video-api

--- a/docker/web-app/src/lib/__tests__/nextConfig.test.ts
+++ b/docker/web-app/src/lib/__tests__/nextConfig.test.ts
@@ -2,20 +2,17 @@ import assert from 'node:assert';
 import test from 'node:test';
 import pkg from '../../../package.json';
 
-test('next.config defines caching headers', async () => {
+test('next.config defines caching headers without unsupported flags', async () => {
   // @ts-ignore next.config.mjs has no type declarations
   const { default: config } = await import('../../../next.config.mjs');
   const headers = await (config as any).headers();
   const staticRule = headers.find((h: any) => h.source === '/_next/static/:path*');
   assert.ok(staticRule, 'static header rule missing');
-  assert.equal((config as any).experimental?.precompile, true);
+  assert.ok(!(config as any).experimental?.precompile, 'precompile flag should be removed');
 });
 
-test('Next.js version supports precompile', () => {
+test('Next.js version is at least 14', () => {
   const version = pkg.dependencies?.next?.replace(/^\D*/, '') || '0.0.0';
-  const [major, minor] = version.split('.').map(Number);
-  assert.ok(
-    major > 14 || (major === 14 && minor >= 2),
-    `Next.js version ${version} is too old for precompile`
-  );
+  const [major] = version.split('.').map(Number);
+  assert.ok(major >= 14, `Next.js version ${version} is too old`);
 });


### PR DESCRIPTION
Milestone: 🧬 Feature Development
Scope: web-app
Linked Issues: none

## Summary
- remove experimental precompile option from Next.js config
- adjust nextConfig test for new behaviour
- drop precompile notes from web-app README

## Testing
- `npm test`

## Checklist
- [ ] Code is self-contained and idempotent.
- [ ] No unnecessary new files or external dependencies.
- [ ] Tests added or updated as appropriate.
- [ ] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_68aa5630ebf483268b7976de2e45ce6d