### PR TITLE
fix: guard ReactQueryDevtools import and enable MQ in dev

### DIFF
--- a/docker/compose/docker-compose.video-web.yaml
+++ b/docker/compose/docker-compose.video-web.yaml
@@ -33,7 +33,7 @@ services:
     networks: [damnet]
     environment:
       NODE_ENV: development
-      DEV_SKIP_MQ: "1"
+      DEV_SKIP_MQ: "0"
       AMQP_CONNECT_TIMEOUT_MS: 2000
       AMQP_CONNECT_ATTEMPTS: 1
       NEXT_PUBLIC_API_BASE_URL: "http://video-api:8080"

--- a/docker/web-app/README.md
+++ b/docker/web-app/README.md
@@ -15,7 +15,7 @@ Test locally with:
 ```bash
 # run the dev server (binds 0.0.0.0 so LAN devices can connect)
 # RabbitMQ must be running (e.g. `docker compose up rabbitmq`)
-# or skip broker connect with `DEV_SKIP_MQ=1`
+# set `DEV_SKIP_MQ=1` to skip broker connect during UI-only work
 
 cd docker/web-app
 yarn dev
@@ -279,7 +279,7 @@ NEXT_PUBLIC_API_BASE_URL=http://localhost:8080
 NEXT_PUBLIC_WS_URL=ws://localhost:8080/ws
 TENANCY_URL=http://localhost:8082/tenants
 NODE_ENV=development
-# DEV_SKIP_MQ=1     # optional: skip RabbitMQ connect during UI work
+# DEV_SKIP_MQ=1     # optional: skip RabbitMQ connect during UI work (unset or set to 0 to re-enable)
 ```
 
 ## API Mappings

--- a/docker/web-app/src/providers/loadReactQueryDevtools.tsx
+++ b/docker/web-app/src/providers/loadReactQueryDevtools.tsx
@@ -23,7 +23,7 @@ export const ReactQueryDevtools: ComponentType<any> = Enabled
   ? dynamic(
       () =>
         import('@tanstack/react-query-devtools').then(
-          (m) => m.ReactQueryDevtools,
+          (m) => m.ReactQueryDevtools ?? m.default,
         ),
       { ssr: false },
     )

--- a/docker/web-app/start.js
+++ b/docker/web-app/start.js
@@ -41,6 +41,10 @@ async function main() {
         : spawn('next', startArgs, { stdio: ['ignore', 'pipe', 'pipe'] }))
     : spawn('next', devArgs, { stdio: ['ignore', 'pipe', 'pipe'] });
 
+  const forward = (sig) => { try { child.kill(sig); } catch (_) {} };
+  process.on('SIGINT', forward);
+  process.on('SIGTERM', forward);
+
   let sent = false;
   child.stdout.on('data', async (data) => {
     const text = data.toString();


### PR DESCRIPTION
Milestone: 🧬 Feature Development
Scope: web-app
Linked Issues: N/A

## Summary
- prevent undefined factories by falling back to default export when dynamically loading React Query Devtools
- forward SIGINT/SIGTERM to Next.js dev server to avoid npm path errors
- enable MQ connection by default in docker compose

## Testing
- `npm test`

## Checklist
- [x] Code is self-contained and idempotent.
- [x] No unnecessary new files or external dependencies.
- [x] Tests added or updated as appropriate.
- [x] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_68aa826ca1e08326bb126de70845e400