### PR TITLE
fix: restore QueryProvider and disable react query devtools

### DIFF
--- a/docker/web-app/README.md
+++ b/docker/web-app/README.md
@@ -34,7 +34,7 @@ Then open http://localhost:3000/signup in your browser.
 
 ## Development Tools
 
- - TanStack React Query Devtools are included by default (set `NEXT_PUBLIC_ENABLE_REACT_DEVTOOLS=0` to disable).
+- TanStack React Query Devtools are disabled by default (set `NEXT_PUBLIC_ENABLE_REACT_DEVTOOLS=1` to enable).
 - A React DevTools server also runs in development; visit
   http://localhost:8097 to inspect component trees without installing a
   browser extension.
@@ -181,7 +181,6 @@ web-app/.
 │   │   ├── CaptureContext.tsx
 │   │   ├── CaptureProvider.tsx
 │   │   ├── ModalProvider.tsx
-│   │   ├── QueryProvider.tsx
 │   │   ├── README.md
 │   │   └── VideoSocketProvider.tsx
 │   ├── state

--- a/docker/web-app/package.json
+++ b/docker/web-app/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "dev": "NEXT_PUBLIC_ENABLE_REACT_DEVTOOLS=1 node start.js dev",
+    "dev": "node start.js dev",
     "build": "next build",
     "start": "NODE_ENV=production node start.js start",
     "export": "next export -o build",

--- a/docker/web-app/src/providers/AppProviders.tsx
+++ b/docker/web-app/src/providers/AppProviders.tsx
@@ -1,26 +1,14 @@
 'use client';
 
-import { ReactNode, useState } from 'react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactNode } from 'react';
 import { SessionProvider } from 'next-auth/react';
 
-import LoadReactQueryDevtools from './loadReactQueryDevtools';
-
-let singletonQc: QueryClient | null = null;
-function getClient() {
-  if (!singletonQc) singletonQc = new QueryClient();
-  return singletonQc;
-}
+import QueryProvider from './QueryProvider';
 
 export default function AppProviders({ children }: { children: ReactNode }) {
-  const [qc] = useState(getClient);
-
   return (
     <SessionProvider>
-      <QueryClientProvider client={qc}>
-        {children}
-        <LoadReactQueryDevtools />
-      </QueryClientProvider>
+      <QueryProvider>{children}</QueryProvider>
     </SessionProvider>
   );
 }

--- a/docker/web-app/src/providers/QueryProvider.tsx
+++ b/docker/web-app/src/providers/QueryProvider.tsx
@@ -1,13 +1,23 @@
-// /docker/web-app/src/providers/QueryProvider.tsx
 'use client';
+
+import { ReactNode, useState } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
-export default function QueryProvider({ children }: { children: React.ReactNode }) {
-  const queryClient = new QueryClient();
+
+import LoadReactQueryDevtools from './loadReactQueryDevtools';
+
+let client: QueryClient | null = null;
+function getClient() {
+  if (!client) client = new QueryClient();
+  return client;
+}
+
+export default function QueryProvider({ children }: { children: ReactNode }) {
+  const [qc] = useState(getClient);
+
   return (
-    <QueryClientProvider client={queryClient}>
+    <QueryClientProvider client={qc}>
       {children}
-      <ReactQueryDevtools initialIsOpen={false} />
+      <LoadReactQueryDevtools />
     </QueryClientProvider>
   );
 }

--- a/docker/web-app/src/providers/__tests__/QueryProvider.test.tsx
+++ b/docker/web-app/src/providers/__tests__/QueryProvider.test.tsx
@@ -1,0 +1,17 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+
+import QueryProvider from '../QueryProvider';
+
+// Example: node --test src/providers/__tests__/QueryProvider.test.tsx
+
+test('QueryProvider renders children', () => {
+  const html = renderToString(
+    <QueryProvider>
+      <div id="child">hello</div>
+    </QueryProvider>
+  );
+  assert.ok(html.includes('hello'));
+});

--- a/docker/web-app/src/providers/loadReactQueryDevtools.tsx
+++ b/docker/web-app/src/providers/loadReactQueryDevtools.tsx
@@ -15,9 +15,10 @@ import dynamic from 'next/dynamic';
 
 const DEV = process.env.NODE_ENV === 'development';
 const Enabled =
+  typeof window !== 'undefined' &&
   DEV &&
-  process.env.NEXT_PUBLIC_ENABLE_REACT_DEVTOOLS !== '0' &&
-  process.env.NEXT_PUBLIC_ENABLE_REACT_DEVTOOLS !== 'false';
+  (process.env.NEXT_PUBLIC_ENABLE_REACT_DEVTOOLS === '1' ||
+    process.env.NEXT_PUBLIC_ENABLE_REACT_DEVTOOLS === 'true');
 
 export const ReactQueryDevtools: ComponentType<any> = Enabled
   ? dynamic(
@@ -31,6 +32,16 @@ export const ReactQueryDevtools: ComponentType<any> = Enabled
 
 export default function LoadReactQueryDevtools() {
   if (!Enabled) return null;
-  return <ReactQueryDevtools initialIsOpen={false} position="bottom-right" />;
+  try {
+    return (
+      <ReactQueryDevtools
+        initialIsOpen={false}
+        position="bottom-right"
+      />
+    );
+  } catch (err: any) {
+    console.warn('[ReactQueryDevtools] failed:', err.message);
+    return null;
+  }
 }
 


### PR DESCRIPTION
Milestone: 🧬 Feature Development
Scope: web-app
Linked Issues: n/a

## Summary
- restore QueryProvider to match existing provider scaffolding
- keep React Query devtools opt-in via env toggle
- add test ensuring QueryProvider renders children

## Testing
- `cd docker/web-app && npm test`

## Checklist
- [x] Code is self-contained and idempotent.
- [x] No unnecessary new files or external dependencies.
- [x] Tests added or updated as appropriate.
- [x] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_68ab376d40748326bb1e18534b37886e