### PR TITLE
feat(web-app): add gradient theme presets

### DIFF
--- a/docker/web-app/src/components/__tests__/TopBar.test.tsx
+++ b/docker/web-app/src/components/__tests__/TopBar.test.tsx
@@ -32,6 +32,7 @@ test('TopBar shows theme dropdown', () => {
   )
   assert.ok(html.includes('Select color scheme'))
   assert.ok(html.includes('sepia'))
+  assert.ok(html.includes('cybernetic-sunset'))
 })
 
 test('Sidebar shows titles when expanded', () => {

--- a/docker/web-app/src/context/ThemeContext.tsx
+++ b/docker/web-app/src/context/ThemeContext.tsx
@@ -7,7 +7,24 @@ import {
   useTheme as useNextTheme,
 } from 'next-themes'
 
-export const AVAILABLE_SCHEMES = ['light', 'dark', 'sepia', 'royal'] as const
+export const AVAILABLE_SCHEMES = [
+  'light',
+  'dark',
+  'sepia',
+  'royal',
+  'cybernetic-sunset',
+  'cosmic-fusion',
+  'aurora-borealis',
+  'neon-metropolis',
+  'digital-twilight',
+  'emerald-depths',
+  'lava-flow',
+  'arctic-frost',
+  'quantum-realm',
+  'bioluminescence',
+  'synthwave-sunset',
+  'nebula-burst',
+] as const
 export type ColorScheme = (typeof AVAILABLE_SCHEMES)[number]
 
 export function ThemeProvider({ children }: { children: ReactNode }) {

--- a/docker/web-app/src/styles/README.md
+++ b/docker/web-app/src/styles/README.md
@@ -63,8 +63,26 @@ Changing these values updates the global background and accent colors without to
 ### Color Schemes
 
 `ThemeProvider` wraps [`next-themes`](https://github.com/pacocoursey/next-themes) and applies a `data-theme` attribute on the
-root element. Predefined schemes (`light`, `dark`, `sepia`, `royal`) are driven by the variables in `tokens.css`, and the top bar
-dropdown lets users switch schemes at runtime.
+root element. Predefined schemes include:
+
+- `light`
+- `dark`
+- `sepia`
+- `royal`
+- `cybernetic-sunset`
+- `cosmic-fusion`
+- `aurora-borealis`
+- `neon-metropolis`
+- `digital-twilight`
+- `emerald-depths`
+- `lava-flow`
+- `arctic-frost`
+- `quantum-realm`
+- `bioluminescence`
+- `synthwave-sunset`
+- `nebula-burst`
+
+These schemes are driven by the variables in `tokens.css`, and the top bar dropdown lets users switch schemes at runtime.
 
 ## Color Tokens
 

--- a/docker/web-app/src/styles/tokens.css
+++ b/docker/web-app/src/styles/tokens.css
@@ -245,3 +245,76 @@
   --theme-primary      : #7e22ce;
   --theme-accent       : #b45309;
 }
+
+/* Additional gradient themes */
+[data-theme='cybernetic-sunset'] {
+  --theme-background: #16213e;
+  --theme-primary: #00ff87;
+  --theme-accent: #ffa500;
+}
+
+[data-theme='cosmic-fusion'] {
+  --theme-background: #0f0e17;
+  --theme-primary: #ff00ff;
+  --theme-accent: #00ffff;
+}
+
+[data-theme='aurora-borealis'] {
+  --theme-background: #0b1d51;
+  --theme-primary: #00ff87;
+  --theme-accent: #ff6fb5;
+}
+
+[data-theme='neon-metropolis'] {
+  --theme-background: #0b0c10;
+  --theme-primary: #66fcf1;
+  --theme-accent: #ff00ff;
+}
+
+[data-theme='digital-twilight'] {
+  --theme-background: #2d00f7;
+  --theme-primary: #f20089;
+  --theme-accent: #00ffff;
+}
+
+[data-theme='emerald-depths'] {
+  --theme-background: #004d40;
+  --theme-primary: #1de9b6;
+  --theme-accent: #ffc107;
+}
+
+[data-theme='lava-flow'] {
+  --theme-background: #3e1e68;
+  --theme-primary: #ff5722;
+  --theme-accent: #ffc107;
+}
+
+[data-theme='arctic-frost'] {
+  --theme-background: #e0f7fa;
+  --theme-primary: #4fc3f7;
+  --theme-accent: #ff8a65;
+}
+
+[data-theme='quantum-realm'] {
+  --theme-background: #1a237e;
+  --theme-primary: #00bcd4;
+  --theme-accent: #ffc400;
+}
+
+[data-theme='bioluminescence'] {
+  --theme-background: #004d40;
+  --theme-primary: #18ffff;
+  --theme-accent: #76ff03;
+}
+
+[data-theme='synthwave-sunset'] {
+  --theme-background: #ff6b6b;
+  --theme-primary: #ff6b6b;
+  --theme-accent: #4ecdc4;
+}
+
+[data-theme='nebula-burst'] {
+  --theme-background: #41295a;
+  --theme-primary: #ff61d2;
+  --theme-accent: #5efce8;
+}


### PR DESCRIPTION
Milestone: 🧬 Feature Development
Scope: web-app
Linked Issues: #0

## Summary
- Add twelve new gradient theme presets to dropdown and theme context.
- Define background, primary, and accent variables for new themes.
- Document and test updated scheme list.

## Testing
- `npm --prefix docker/web-app test`

- [x] Code is self-contained and idempotent.
- [x] No unnecessary new files or external dependencies.
- [x] Tests added or updated as appropriate.
- [x] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_68ab86c66ee483269ad49131c3422cad