### PR TITLE
fix: stabilize web-app SSR and reduce session polling

### DIFF
--- a/docker/web-app/README.md
+++ b/docker/web-app/README.md
@@ -291,6 +291,8 @@ TENANCY_URL=http://localhost:8082/tenants
 NODE_ENV=development
 NEXTAUTH_URL=http://localhost:3000
 NEXTAUTH_SECRET=changeme
+# Set to "true" to enable verbose NextAuth logs
+NEXTAUTH_DEBUG=false
 # DEV_SKIP_MQ=1     # optional: skip RabbitMQ connect during UI work (unset or set to 0 to re-enable)
 ```
 

--- a/docker/web-app/src/app/[tenant]/dashboard/camera-monitor/page.tsx
+++ b/docker/web-app/src/app/[tenant]/dashboard/camera-monitor/page.tsx
@@ -2,12 +2,14 @@
 'use client';
 
 import safeDynamic from '@/lib/safeDynamic';
-import CameraMonitor from '@components/CameraMonitor';
 
-/* lazy-load the merged CaptureProvider so it doesn’t end up in your
-   main bundle (and you don’t need CaptureProviderImpl anymore) */
 const CaptureProvider = safeDynamic(
   () => import('@/providers/CaptureProvider'),
+  { ssr: false }
+);
+
+const CameraMonitor = safeDynamic(
+  () => import('@components/CameraMonitor'),
   { ssr: false }
 );
 

--- a/docker/web-app/src/app/[tenant]/dashboard/dam-explorer/page.tsx
+++ b/docker/web-app/src/app/[tenant]/dashboard/dam-explorer/page.tsx
@@ -1,11 +1,12 @@
 // app/dashboard/dam-explorer/page.tsx
 'use client';
-import DAMExplorer from '@/components/DAMExplorer';
+import safeDynamic from '@/lib/safeDynamic';
+
+const DAMExplorer = safeDynamic(
+  () => import('@/components/DAMExplorer'),
+  { ssr: false }
+);
 
 export default function DAMExplorerPage() {
-  return (
-    <div className="w-full h-full">
-      <DAMExplorer />
-    </div>
-  );
+  return <DAMExplorer />;
 }

--- a/docker/web-app/src/components/Sidebar.tsx
+++ b/docker/web-app/src/components/Sidebar.tsx
@@ -6,17 +6,20 @@ import { dashboardTools } from './dashboardTools'
 import clsx from 'clsx'
 import { useSidebar } from '../hooks/useSidebar'
 import { useTenant } from '@/providers/TenantProvider'
+import { useIsClient } from '@/hooks/useIsClient'
 
 export default function Sidebar() {
   const { collapsed } = useSidebar()
   const pathname = usePathname() || ''
   const tenant = useTenant()
+  const isClient = useIsClient()
+  const effectiveCollapsed = isClient ? collapsed : false
 
   return (
     <aside
       className={clsx(
         'h-full overflow-hidden bg-surface border-r border-color-border shadow-lg transition-all duration-300',
-        collapsed ? 'w-0 md:w-16' : 'w-64'
+        effectiveCollapsed ? 'w-0 md:w-16' : 'w-64'
       )}
     >
       <nav className="flex flex-col gap-1 px-2 py-2">
@@ -33,7 +36,7 @@ export default function Sidebar() {
               )}
             >
               <Icon className="text-lg shrink-0" />
-              {!collapsed && <span className="text-body">{title}</span>}
+              {!effectiveCollapsed && <span className="text-body">{title}</span>}
             </Link>
           )
         })}

--- a/docker/web-app/src/components/TopBar.tsx
+++ b/docker/web-app/src/components/TopBar.tsx
@@ -6,11 +6,13 @@ import { Menu, X } from 'lucide-react'
 import { useSidebar } from '../hooks/useSidebar'
 import { useModal } from '@/providers/ModalProvider'
 import { useTheme, AVAILABLE_SCHEMES, ColorScheme } from '@/context/ThemeContext'
+import { useIsClient } from '@/hooks/useIsClient'
 
 export default function TopBar() {
   const { collapsed, setCollapsed } = useSidebar()
   const { openModal } = useModal()
   const { scheme, setScheme } = useTheme()
+  const isClient = useIsClient()
 
   return (
     <header
@@ -23,10 +25,11 @@ export default function TopBar() {
       <div className="flex items-center gap-2">
         <button
           aria-label="Toggle sidebar"
-          onClick={() => setCollapsed(!collapsed)}
+          disabled={!isClient}
+          onClick={isClient ? () => setCollapsed(!collapsed) : undefined}
           className="p-2 rounded-md text-color-muted hover:text-theme-primary hover:bg-color-primary-bg"
         >
-          {collapsed ? <Menu size={20} /> : <X size={20} />}
+          {isClient && !collapsed ? <X size={20} /> : <Menu size={20} />}
         </button>
         <a href="/" className="text-heading">
           That DAM Toolbox
@@ -39,6 +42,7 @@ export default function TopBar() {
           aria-label="Select color scheme"
           value={scheme}
           onChange={e => setScheme(e.target.value as ColorScheme)}
+          disabled={!isClient}
           className="input text-sm"
         >
           {AVAILABLE_SCHEMES.map(opt => (
@@ -47,7 +51,8 @@ export default function TopBar() {
         </select>
         <button
           type="button"
-          onClick={() => openModal('dam-explorer')}
+          disabled={!isClient}
+          onClick={isClient ? () => openModal('dam-explorer') : undefined}
           className="text-body hover:text-theme-primary"
         >
           Explorer

--- a/docker/web-app/src/hooks/__tests__/useIsClient.test.tsx
+++ b/docker/web-app/src/hooks/__tests__/useIsClient.test.tsx
@@ -1,0 +1,16 @@
+import assert from 'node:assert';
+import test from 'node:test';
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+import { useIsClient } from '../useIsClient';
+
+// Example: node --test src/hooks/__tests__/useIsClient.test.tsx
+
+test('returns false during server render', () => {
+  function Comp() {
+    const isClient = useIsClient();
+    return <span>{String(isClient)}</span>;
+  }
+  const html = renderToString(<Comp />);
+  assert.equal(html, '<span>false</span>');
+});

--- a/docker/web-app/src/hooks/__tests__/useMediaQuery.test.tsx
+++ b/docker/web-app/src/hooks/__tests__/useMediaQuery.test.tsx
@@ -1,0 +1,16 @@
+import assert from 'node:assert';
+import test from 'node:test';
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+import { useMediaQuery } from '../useMediaQuery';
+
+// Example: node --test src/hooks/__tests__/useMediaQuery.test.tsx
+
+test('uses ssrMatch on server render', () => {
+  function Comp() {
+    const match = useMediaQuery('(max-width: 600px)', true);
+    return <span>{match ? 'yes' : 'no'}</span>;
+  }
+  const html = renderToString(<Comp />);
+  assert.equal(html, '<span>yes</span>');
+});

--- a/docker/web-app/src/hooks/useIsClient.ts
+++ b/docker/web-app/src/hooks/useIsClient.ts
@@ -1,0 +1,14 @@
+'use client';
+import { useEffect, useState } from 'react';
+
+/**
+ * useIsClient – returns true after the component mounts on the client.
+ *
+ * Example:
+ *   const isClient = useIsClient();
+ */
+export function useIsClient(): boolean {
+  const [isClient, setIsClient] = useState(false);
+  useEffect(() => setIsClient(true), []);
+  return isClient;
+}

--- a/docker/web-app/src/hooks/useMediaQuery.ts
+++ b/docker/web-app/src/hooks/useMediaQuery.ts
@@ -1,0 +1,23 @@
+'use client';
+import { useEffect, useState } from 'react';
+
+/**
+ * useMediaQuery – evaluate a CSS media query in a React-friendly, SSR-safe way.
+ *
+ * Example:
+ *   const isNarrow = useMediaQuery('(max-width: 600px)', false);
+ */
+export function useMediaQuery(query: string, ssrMatch = false): boolean {
+  const [matches, setMatches] = useState<boolean>(ssrMatch);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const mql = window.matchMedia(query);
+    const handler = () => setMatches(mql.matches);
+    handler();
+    mql.addEventListener?.('change', handler);
+    return () => mql.removeEventListener?.('change', handler);
+  }, [query]);
+
+  return matches;
+}

--- a/docker/web-app/src/hooks/useOrientation.ts
+++ b/docker/web-app/src/hooks/useOrientation.ts
@@ -14,19 +14,21 @@ export type Orientation = 'portrait' | 'landscape';
  */
 export function getOrientation(win?: { innerWidth: number; innerHeight: number }): Orientation {
   if (!win) return 'landscape';
-  return win.innerWidth > win.innerHeight ? 'landscape' : 'portrait';
+  return win.innerHeight >= win.innerWidth ? 'portrait' : 'landscape';
 }
 
 export function useOrientation(): Orientation {
-  const [orientation, setOrientation] = useState<Orientation>(() => getOrientation(typeof window !== 'undefined' ? window : undefined));
+  const [orientation, setOrientation] = useState<Orientation>('landscape');
 
   useEffect(() => {
-    const handle = () => setOrientation(getOrientation(window));
-    window.addEventListener('resize', handle);
-    window.addEventListener('orientationchange', handle);
+    const calc = () => getOrientation(window);
+    const onResize = () => setOrientation(calc());
+    setOrientation(calc());
+    window.addEventListener('resize', onResize);
+    window.addEventListener('orientationchange', onResize);
     return () => {
-      window.removeEventListener('resize', handle);
-      window.removeEventListener('orientationchange', handle);
+      window.removeEventListener('resize', onResize);
+      window.removeEventListener('orientationchange', onResize);
     };
   }, []);
 

--- a/docker/web-app/src/hooks/useOrientationAspect.ts
+++ b/docker/web-app/src/hooks/useOrientationAspect.ts
@@ -27,7 +27,7 @@ export default function useOrientationAspect<T extends HTMLElement>(
   ref: RefObject<T>
 ): OrientationAspect {
   const orientation = useOrientation();
-  const [aspect, setAspect] = useState<number | null>(null);
+  const [aspect, setAspect] = useState<number | null>(16 / 9);
 
   useEffect(() => {
     const el = ref.current;

--- a/docker/web-app/src/lib/auth.ts
+++ b/docker/web-app/src/lib/auth.ts
@@ -61,6 +61,6 @@ export function getAuthOptions(): NextAuthOptions {
         return session;
       },
     },
-    debug: !isProd,
+    debug: process.env["NEXTAUTH_DEBUG"] === 'true',
   };
 }

--- a/docker/web-app/src/providers/AppProviders.tsx
+++ b/docker/web-app/src/providers/AppProviders.tsx
@@ -30,7 +30,11 @@ export default function AppProviders({ children }: { children: React.ReactNode }
   );
 
   return (
-    <SessionProvider>
+    <SessionProvider
+      refetchOnWindowFocus={false}
+      refetchWhenOffline={false}
+      refetchInterval={0}
+    >
       <QueryClientProvider client={qc}>
         <ClientOnly>
           <ThemeProvider attribute="class" defaultTheme="system" enableSystem>

--- a/docker/web-app/src/providers/AssetProvider.tsx
+++ b/docker/web-app/src/providers/AssetProvider.tsx
@@ -34,9 +34,13 @@ export default function AssetProvider({ children }: { children: React.ReactNode 
   const { data, isFetching } = useQuery({
     queryKey: ['assets', refreshTick],
     queryFn: async () => {
-      const res = await fetch('/api/library/stats', { cache: 'no-store' });
-      if (!res.ok) return { assetsList: [] as Asset[] };
-      return (await res.json()) as { assetsList: Asset[] };
+      try {
+        const res = await fetch('/api/library/stats', { cache: 'no-store' });
+        if (!res.ok) return { assetsList: [] as Asset[] };
+        return (await res.json()) as { assetsList: Asset[] };
+      } catch {
+        return { assetsList: [] as Asset[] };
+      }
     },
     initialData: { assetsList: [] as Asset[] },
     refetchOnMount: false,

--- a/docker/web-app/src/styles/globals.css
+++ b/docker/web-app/src/styles/globals.css
@@ -3,12 +3,12 @@
 
 /* Fallback theme values for SSR */
 :root {
-  --background: #0b0f14;
-  --foreground: #dfe7f5;
+  --color-background: #0b0f14;
+  --color-text: #dfe7f5;
 }
 
-.bg-background { background: var(--background); }
-.text-foreground { color: var(--foreground); }
+.bg-background { background: var(--color-background); }
+.text-foreground { color: var(--color-text); }
 
 @tailwind base;
 @tailwind components;

--- a/docker/web-app/tsconfig.test.json
+++ b/docker/web-app/tsconfig.test.json
@@ -18,6 +18,8 @@
     "src/providers/__tests__/AssetProvider.test.tsx",
     "src/hooks/__tests__/useOrientation.test.ts",
     "src/hooks/__tests__/useOrientationAspect.test.ts",
+    "src/hooks/__tests__/useIsClient.test.tsx",
+    "src/hooks/__tests__/useMediaQuery.test.tsx",
     "src/app/__tests__/login.test.tsx",
     "src/app/__tests__/account.test.tsx",
     "src/app/__tests__/dashboardRoutes.test.tsx",


### PR DESCRIPTION
Milestone: 🧬 Feature Development
Scope: web-app
Linked Issues: N/A

## Summary
- disable repeated session refetches and guard auth debug with `NEXTAUTH_DEBUG`
- harden client hooks for SSR, dynamically load client-only pages
- normalize global color variables and document `NEXTAUTH_DEBUG`

## Testing
- `npm test`
- `npm run lint` *(fails: React hooks called conditionally and other existing warnings)*

## Checklist
- [x] Code is self-contained and idempotent.
- [x] No unnecessary new files or external dependencies.
- [x] Tests added or updated as appropriate.
- [x] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_68ab8c2249748326a0169d93c2422110