### PR TITLE
fix: avoid stale next chunks in dev

### DIFF
--- a/docker/web-app/next.config.mjs
+++ b/docker/web-app/next.config.mjs
@@ -21,11 +21,19 @@ const nextConfig = {
   },
 
   async headers() {
+    const isDev = process.env.NODE_ENV === 'development';
     return [
-      // cache Next static assets aggressively
+      // cache Next static assets aggressively in prod, disable in dev to avoid stale chunks
       {
         source: '/_next/static/:path*',
-        headers: [{ key: 'Cache-Control', value: 'public, max-age=31536000, immutable' }],
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: isDev
+              ? 'no-store'
+              : 'public, max-age=31536000, immutable',
+          },
+        ],
       },
       // thumbs
       {

--- a/docker/web-app/src/lib/__tests__/nextConfig.test.ts
+++ b/docker/web-app/src/lib/__tests__/nextConfig.test.ts
@@ -11,6 +11,31 @@ test('next.config defines caching headers without unsupported flags', async () =
   assert.ok(!(config as any).experimental?.precompile, 'precompile flag should be removed');
 });
 
+test('disables static asset caching in development', async () => {
+  // @ts-ignore next.config.mjs has no type declarations
+  const { default: config } = await import('../../../next.config.mjs');
+  const origEnv = process.env.NODE_ENV;
+  (process.env as any).NODE_ENV = 'development';
+  const headers = await (config as any).headers();
+  const staticRule = headers.find((h: any) => h.source === '/_next/static/:path*');
+  assert.equal(staticRule.headers[0].value, 'no-store');
+  (process.env as any).NODE_ENV = origEnv;
+});
+
+test('caches static assets in production', async () => {
+  // @ts-ignore next.config.mjs has no type declarations
+  const { default: config } = await import('../../../next.config.mjs');
+  const origEnv = process.env.NODE_ENV;
+  (process.env as any).NODE_ENV = 'production';
+  const headers = await (config as any).headers();
+  const staticRule = headers.find((h: any) => h.source === '/_next/static/:path*');
+  assert.equal(
+    staticRule.headers[0].value,
+    'public, max-age=31536000, immutable',
+  );
+  (process.env as any).NODE_ENV = origEnv;
+});
+
 test('Next.js version is at least 14', () => {
   const version = pkg.dependencies?.next?.replace(/^\D*/, '') || '0.0.0';
   const [major] = version.split('.').map(Number);


### PR DESCRIPTION
Milestone: 🧬 Feature Development
Scope: web-app
Linked Issues: N/A

## Summary
- disable caching of Next.js static chunks during development
- test cache headers for dev and prod configurations

## Testing
- `npm test` *(fails: TS compile errors)*
- `npm run lint`

## Checklist
- [x] Code is self-contained and idempotent.
- [x] No unnecessary new files or external dependencies.
- [x] Tests added or updated as appropriate.
- [ ] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_68ab9378374883269fbd7497ddd5a4cb