### PR TITLE
fix(web-app): handle missing assets in DAM explorer

### DIFF
--- a/docker/web-app/src/components/DAMExplorer/AssetExplorer.tsx
+++ b/docker/web-app/src/components/DAMExplorer/AssetExplorer.tsx
@@ -43,8 +43,19 @@ interface UndoOperation {
 
 // Main Component: AssetExplorer
 const AssetExplorer: React.FC = () => {
-  const { view: rawView, folders, foldersLoading, move, remove, refresh, setFilters, filters, vectorSearch } = useAssets()
-  const assets = rawView as Asset[]
+  const {
+    view: rawView,
+    assets: assetList = [],
+    folders = [],
+    foldersLoading = false,
+    move = async () => {},
+    remove = async () => {},
+    refresh = () => {},
+    setFilters = () => {},
+    filters = {},
+    vectorSearch = async () => [],
+  } = useAssets() as any
+  const assets = (rawView ?? assetList) as Asset[]
   const { ids: selectedAssets, clear: clearSelection } = useSelection()
   const [currentPath, setCurrentPath] = useState<string>('')
   const [viewMode, setViewMode] = useState<'grid' | 'list'>('grid')

--- a/docker/web-app/src/components/DAMExplorer/helpers.ts
+++ b/docker/web-app/src/components/DAMExplorer/helpers.ts
@@ -33,7 +33,7 @@ export const toSearchResult = (asset: Asset): SearchResult => ({
 })
 
 export const filterAssets = (
-  assets: Asset[],
+  assets: Asset[] = [],
   query: string,
   filters?: SearchFilters,
 ): SearchResult[] => {
@@ -71,7 +71,7 @@ export const performVectorSearch = async (
   }
 }
 
-export const findAssetById = (assets: Asset[], id: string) =>
+export const findAssetById = (assets: Asset[] = [], id: string) =>
   assets.find((a) => a.id === id)
 
 export const confirmDeletion = async (

--- a/docker/web-app/src/components/LayeredFS/LayeredExplorer.tsx
+++ b/docker/web-app/src/components/LayeredFS/LayeredExplorer.tsx
@@ -24,7 +24,7 @@ import type { TreeSnapshot, TreeNode, FolderNode } from './types';
 // Build a TreeSnapshot from provider data
 function buildSnapshot(
   folders: Array<{ name: string; path: string; children: any[] }>,
-  assets: Array<{ id: string; name: string; path: string; thumbnail?: string; mime?: string; size?: number; kind?: string }>,
+  assets: Array<{ id: string; name: string; path: string; thumbnail?: string; mime?: string; size?: number; kind?: string }> = [],
 ): TreeSnapshot {
   const nodes: Record<string, TreeNode> = {};
   const pathId = (p: string) => (p === '/' || p === '' ? 'root' : p);
@@ -201,7 +201,13 @@ function roundedRectShape(w: number, h: number, r: number) {
 }
 
 export default function LayeredExplorer() {
-  const { view: assets, folders, foldersLoading } = useAssets();
+  const {
+    view: assetsView,
+    assets: assetList = [],
+    folders = [],
+    foldersLoading = false,
+  } = useAssets() as any;
+  const assets = (assetsView ?? assetList) as any[];
 
   const getCols = (w: number) => (w < 640 ? 2 : w < 1024 ? 4 : 6);
   const [cols, setCols] = useState(() => (typeof window === 'undefined' ? 6 : getCols(window.innerWidth)));

--- a/docker/web-app/src/components/__tests__/AssetExplorer.test.tsx
+++ b/docker/web-app/src/components/__tests__/AssetExplorer.test.tsx
@@ -58,3 +58,8 @@ test('confirmDeletion respects user choice', async () => {
   assert.strictEqual(removed.length, 1)
 })
 
+test('filterAssets handles undefined input', () => {
+  const results = filterAssets(undefined as any, 'test')
+  assert.deepStrictEqual(results, [])
+})
+

--- a/docker/web-app/tsconfig.test.json
+++ b/docker/web-app/tsconfig.test.json
@@ -31,6 +31,7 @@
     "src/lib/__tests__/safeDynamic.test.tsx",
     "src/styles/__tests__/tokens.test.ts",
     "src/components/__tests__/uiUxTasks.test.ts",
+    "src/components/__tests__/AssetExplorer.test.tsx",
     "src/components/__tests__/TopBar.test.tsx",
     "src/lib/server/__tests__/settingsDB.test.ts",
     "src/app/api/policy/__tests__/evaluate.test.ts",


### PR DESCRIPTION
Milestone: 🧬 Feature Development
Scope: web-app
Linked Issues: #0

## Summary
- guard DAM Explorer against missing asset data so theme changes no longer crash
- default asset helpers to tolerate undefined arrays
- cover asset filtering with undefined input

## Testing
- `npm test` *(fails: Cannot find module 'next-themes' and other TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ab94992e4c8326845d19fcd6ebd911