### PR TITLE
fix: wire theme provider via data attribute

### DIFF
--- a/docker/web-app/src/providers/AppProviders.tsx
+++ b/docker/web-app/src/providers/AppProviders.tsx
@@ -3,7 +3,7 @@
 import { ReactNode, useState } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { SessionProvider } from 'next-auth/react';
-import { ThemeProvider } from 'next-themes';
+import { ThemeProvider } from '@/context/ThemeContext';
 
 import TenantProvider from '@/providers/TenantProvider';
 import AuthProvider from '@/providers/AuthProvider';
@@ -38,7 +38,7 @@ export default function AppProviders({ children }: { children: React.ReactNode }
     >
       <QueryClientProvider client={qc}>
         <ClientOnly>
-          <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+          <ThemeProvider>
             <TenantProvider>
               <AuthProvider>
                 <AssetProvider>

--- a/docker/web-app/src/providers/__tests__/AppProviders.test.ts
+++ b/docker/web-app/src/providers/__tests__/AppProviders.test.ts
@@ -1,0 +1,15 @@
+/**
+ * Validate AppProviders wires ThemeContext's ThemeProvider so themes change colors.
+ *
+ * Example:
+ *   npm test
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+test('AppProviders imports ThemeContext provider', () => {
+  const src = readFileSync(join(process.cwd(), 'src/providers/AppProviders.tsx'), 'utf8');
+  assert.match(src, /from '@\/context\/ThemeContext'/);
+});

--- a/docker/web-app/tsconfig.test.json
+++ b/docker/web-app/tsconfig.test.json
@@ -42,7 +42,8 @@
     "src/types/externals.d.ts",
     "src/lib/auth.test.ts",
     "middleware.test.ts",
-    "src/app/__tests__/pair.test.tsx"
+    "src/app/__tests__/pair.test.tsx",
+    "src/providers/__tests__/AppProviders.test.ts"
   ],
   "exclude": []
 }


### PR DESCRIPTION
Milestone: 🧬 Feature Development
Scope: web-app
Linked Issues: none

## Summary
- use ThemeContext's ThemeProvider so tokens swap by `data-theme`
- test that AppProviders wires ThemeContext provider
- enable test compilation for new spec

## Testing
- `npm test` *(fails: TS errors in CameraMonitor and others)*
- `npm run lint`

## Checklist
- [x] Code is self-contained and idempotent.
- [x] No unnecessary new files or external dependencies.
- [x] Tests added or updated as appropriate.
- [ ] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_68ab9769ea648326ac8fc6b03442d5a9