### PR TITLE
fix(web-app): specify next constants extension

### DIFF
--- a/docker/web-app/next.config.mjs
+++ b/docker/web-app/next.config.mjs
@@ -1,6 +1,6 @@
 // /docker/web-app/next.config.mjs
 import path from 'path';
-import { PHASE_DEVELOPMENT_SERVER } from 'next/constants';
+import { PHASE_DEVELOPMENT_SERVER } from 'next/constants.js';
 
 const API_BASE =
   process.env.NEXT_PUBLIC_API_BASE_URL ?? 'http://host.docker.internal:8080';


### PR DESCRIPTION
Milestone: 🧬 Feature Development
Scope: web-app
Linked Issues: N/A

## Summary
- reference `next/constants.js` to avoid `ERR_MODULE_NOT_FOUND` in dev server

## Testing
- `npm test` (fails: TS2554, TS2559, TS2552, etc.)
- `npm run lint` (fails: react-hooks/rules-of-hooks, @typescript-eslint/no-empty-function)

## Checklist
- [x] Code is self-contained and idempotent.
- [x] No unnecessary new files or external dependencies.
- [ ] Tests added or updated as appropriate.
- [ ] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_68ac849b998c832688b13884ab430ac9