### PR TITLE
fix(web-app): keep dev server after warmup

### DIFF
--- a/docker/web-app/README.md
+++ b/docker/web-app/README.md
@@ -14,6 +14,7 @@ Test locally with:
 
 ```bash
 # run the dev server with route warming (binds 0.0.0.0 so LAN devices can connect)
+# warmup exits after pinging routes but `next dev` keeps running
 
 cd docker/web-app
 npm run dev:warm

--- a/docker/web-app/package.json
+++ b/docker/web-app/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbo -p 3000",
-    "dev:warm": "concurrently -k -n next,warmup -c auto \"next dev --turbo -p 3000\" \"tsx scripts/dev-warmup.ts\"",
+    "dev:warm": "concurrently --no-kill-others -n next,warmup -c auto \"next dev --turbo -p 3000\" \"tsx scripts/dev-warmup.ts\"",
     "build": "next build",
     "start": "NODE_ENV=production node start.js start",
     "export": "next export -o build",


### PR DESCRIPTION
Milestone: 🧬 Feature Development
Scope: web-app
Linked Issues: none

## Summary
- keep Next.js dev server running after route warmup by disabling kill-others in concurrent script
- clarify README that warmup exits but dev server continues

## Testing
- `npm test` *(fails: TypeScript compile errors in CameraMonitor and other components)*

## Checklist
- [x] Code is self-contained and idempotent.
- [x] No unnecessary new files or external dependencies.
- [ ] Tests added or updated as appropriate.
- [x] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_68acb53658a08326889a41e3a848a2fd