### PR TITLE
feat: add tenant cookie routing and service status chip

### DIFF
--- a/docker/compose/dev/docker-compose.yml
+++ b/docker/compose/dev/docker-compose.yml
@@ -13,3 +13,21 @@ services:
       WEAVIATE_ENDPOINT: "${WEAVIATE_ENDPOINT:-http://weaviate:8080}"
     network_mode: bridge
     restart: unless-stopped
+
+  web-app:
+    build:
+      context: ../../docker/web-app
+    command: npm run dev
+    environment:
+      NEXT_PUBLIC_MEDIA_API_BASE: ""
+      CHOKIDAR_USEPOLLING: "true"
+      WATCHPACK_POLLING: "true"
+    volumes:
+      - webapp_node_modules:/app/node_modules
+      - webapp_next_cache:/app/.next
+    ports:
+      - "3000:3000"
+
+volumes:
+  webapp_node_modules:
+  webapp_next_cache:

--- a/docker/web-app/middleware.test.ts
+++ b/docker/web-app/middleware.test.ts
@@ -8,19 +8,37 @@ import test from 'node:test';
 import { NextRequest } from 'next/server';
 import { middleware } from './middleware';
 
-test('sets tenant slug header without redirect', () => {
+test('sets tenant slug header without redirect', async () => {
   const req = new NextRequest('http://example.com/acme/dashboard');
-  const res = middleware(req);
+  const res = await middleware(req);
   assert.equal(res.status, 200);
   assert.equal(res.headers.get('x-tenant-slug'), 'acme');
 });
 
-test('tags tenant slug when session cookie is present', () => {
-  const req = new NextRequest('http://example.com/acme/dashboard', {
-    headers: { cookie: 'node_session=abc' },
+test('redirects / when cookie present', async () => {
+  const req = new NextRequest('http://example.com/', {
+    headers: { cookie: 'cda_tenant=acme' },
   });
-  const res = middleware(req);
-  assert.equal(res.headers.get('x-tenant-slug'), 'acme');
-  assert.equal(res.status, 200);
+  const res = await middleware(req);
+  assert.equal(res.status, 307);
+  assert.equal(res.headers.get('location'), 'http://example.com/acme/dashboard');
+});
+
+test('redirects /dashboard using API fallback', async t => {
+  const origFetch = global.fetch;
+  t.after(() => { global.fetch = origFetch });
+  global.fetch = async () => new Response(JSON.stringify({ tenant: 'beta' }), { status: 200 });
+  const req = new NextRequest('http://example.com/dashboard');
+  const res = await middleware(req);
+  assert.equal(res.headers.get('location'), 'http://example.com/beta/dashboard');
+});
+
+test('falls back to /login when no tenant', async t => {
+  const origFetch = global.fetch;
+  t.after(() => { global.fetch = origFetch });
+  global.fetch = async () => new Response('nope', { status: 500 });
+  const req = new NextRequest('http://example.com/');
+  const res = await middleware(req);
+  assert.equal(res.headers.get('location'), 'http://example.com/login');
 });
 

--- a/docker/web-app/middleware.ts
+++ b/docker/web-app/middleware.ts
@@ -1,19 +1,51 @@
 /**
- * Middleware tagging requests with the current tenant slug.
+ * Middleware providing tenant-aware routing and header tagging.
  *
- * Example:
- *   visiting /acme/dashboard sets `x-tenant-slug: acme`
+ * Behaviors:
+ *   - `/` or `/dashboard` redirect to `/{tenant}/dashboard` when a default
+ *     tenant is known (cookie or API), else to `/login`.
+ *   - All other tenant routes receive `x-tenant-slug` response header.
  */
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 
-/**
- * Tags responses with tenant slug and optionally checks local node session.
- * Example:
- *   request /acme/dashboard -> header x-tenant-slug: acme
- */
-export function middleware(req: NextRequest) {
-  const { pathname } = req.nextUrl;
+export async function middleware(req: NextRequest) {
+  const url = new URL(req.url);
+  const { pathname } = url;
+
+  // Skip API and static assets
+  if (
+    pathname.startsWith("/api") ||
+    pathname.startsWith("/_next") ||
+    pathname.startsWith("/favicon") ||
+    pathname.startsWith("/public")
+  )
+    return NextResponse.next();
+
+  // Prefer cookie for default tenant
+  const cookieTenant = req.cookies.get("cda_tenant")?.value ?? null;
+
+  async function getDefaultTenantViaApi(): Promise<string | null> {
+    try {
+      const res = await fetch(new URL("/api/account/default-tenant", url).toString(), {
+        headers: { cookie: req.headers.get("cookie") ?? "" },
+        cache: "no-store",
+      });
+      if (!res.ok) return null;
+      const data = await res.json();
+      const t = data?.tenant?.slug || data?.tenant;
+      return t ? String(t) : null;
+    } catch {
+      return null;
+    }
+  }
+
+  if (pathname === "/" || pathname === "/dashboard") {
+    const tenant = cookieTenant || (await getDefaultTenantViaApi());
+    return NextResponse.redirect(new URL(tenant ? `/${tenant}/dashboard` : "/login", url));
+  }
+
+  // Tag tenant slug header for other routes
   const parts = pathname.split("/").filter(Boolean);
   if (parts.length > 0) {
     const tenant = parts[0];
@@ -24,10 +56,9 @@ export function middleware(req: NextRequest) {
       return res;
     }
   }
+
   return NextResponse.next();
 }
 
-export const config = {
-  matcher: ["/((?!_next|.*\\..*).*)"],
-};
+export const config = { matcher: ["/((?!_next|api|favicon|public).*)"] };
 

--- a/docker/web-app/src/app/[tenant]/account/logout/page.tsx
+++ b/docker/web-app/src/app/[tenant]/account/logout/page.tsx
@@ -1,0 +1,21 @@
+'use client'
+import { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { clearDefaultTenantCookie } from '@/lib/tenancy/cookieClient'
+import { useAuth } from '@/providers/AuthProvider'
+
+/**
+ * Clears tenant cookie then triggers AuthProvider logout.
+ */
+export default function LogoutPage() {
+  const r = useRouter()
+  const { logout } = useAuth()
+  useEffect(() => {
+    ;(async () => {
+      await clearDefaultTenantCookie()
+      await logout()
+      r.replace('/login')
+    })()
+  }, [r, logout])
+  return <p className="p-6 text-sm text-zinc-400">Signing out…</p>
+}

--- a/docker/web-app/src/app/api/account/__tests__/defaultTenantCookie.test.ts
+++ b/docker/web-app/src/app/api/account/__tests__/defaultTenantCookie.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Tests for set/clear default tenant API routes.
+ * Run with: npm test
+ */
+import assert from 'node:assert'
+import test from 'node:test'
+import { POST as setPost } from '../set-default-tenant/route'
+import { POST as clearPost } from '../clear-default-tenant/route'
+
+test('set-default-tenant sets cookie and returns payload', async () => {
+  const req = new Request('http://example.com/api/account/set-default-tenant', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ slug: 'acme' }),
+  })
+  const res = await setPost(req as any)
+  assert.equal(res.status, 200)
+  const cookie = res.headers.get('set-cookie')
+  assert.ok(cookie?.includes('cda_tenant=acme'))
+  const data = await res.json()
+  assert.deepStrictEqual(data, { ok: true, tenant: 'acme' })
+})
+
+test('clear-default-tenant removes cookie', async () => {
+  const req = new Request('http://example.com/api/account/clear-default-tenant', {
+    method: 'POST',
+  })
+  const res = await clearPost(req as any)
+  assert.equal(res.status, 200)
+  const cookie = res.headers.get('set-cookie')
+  assert.ok(cookie?.includes('Max-Age=0'))
+})

--- a/docker/web-app/src/app/api/account/clear-default-tenant/route.ts
+++ b/docker/web-app/src/app/api/account/clear-default-tenant/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server'
+
+/**
+ * POST /api/account/clear-default-tenant
+ *
+ * Example:
+ *   curl -X POST http://localhost:3000/api/account/clear-default-tenant
+ *
+ * Removes the `cda_tenant` cookie set for tenant-first redirects.
+ */
+export async function POST() {
+  const res = NextResponse.json({ ok: true })
+  res.cookies.set({
+    name: 'cda_tenant',
+    value: '',
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: process.env.NODE_ENV === 'production',
+    path: '/',
+    maxAge: 0,
+  })
+  return res
+}

--- a/docker/web-app/src/app/api/account/set-default-tenant/route.ts
+++ b/docker/web-app/src/app/api/account/set-default-tenant/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+/**
+ * POST /api/account/set-default-tenant
+ *
+ * Example:
+ *   curl -X POST -H "Content-Type: application/json" \
+ *     -d '{"slug":"demo"}' http://localhost:3000/api/account/set-default-tenant
+ *
+ * Sets an httpOnly cookie `cda_tenant` so middleware can redirect quickly.
+ */
+export async function POST(req: NextRequest) {
+  try {
+    const { slug } = await req.json()
+    if (!slug || typeof slug !== 'string') {
+      return NextResponse.json({ error: 'slug required' }, { status: 400 })
+    }
+    const res = NextResponse.json({ ok: true, tenant: slug })
+    res.cookies.set({
+      name: 'cda_tenant',
+      value: slug,
+      httpOnly: true,
+      sameSite: 'lax',
+      secure: process.env.NODE_ENV === 'production',
+      path: '/',
+      maxAge: 60 * 60 * 24 * 30, // 30 days
+    })
+    return res
+  } catch {
+    return NextResponse.json({ error: 'bad request' }, { status: 400 })
+  }
+}

--- a/docker/web-app/src/app/login/TenantRedirect.tsx
+++ b/docker/web-app/src/app/login/TenantRedirect.tsx
@@ -1,0 +1,18 @@
+'use client'
+import { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { setDefaultTenantCookie } from '@/lib/tenancy/cookieClient'
+
+/**
+ * Sets default tenant cookie then redirects to the tenant dashboard.
+ */
+export default function TenantRedirect({ tenant }: { tenant: string }) {
+  const r = useRouter()
+  useEffect(() => {
+    ;(async () => {
+      await setDefaultTenantCookie(tenant)
+      r.replace(`/${tenant}/dashboard`)
+    })()
+  }, [tenant, r])
+  return null
+}

--- a/docker/web-app/src/app/login/page.tsx
+++ b/docker/web-app/src/app/login/page.tsx
@@ -3,6 +3,8 @@ import GoogleGISButton from '@/components/auth/GoogleGISButton';
 import { getServerSession } from 'next-auth/next';
 import { getAuthOptions } from '@/lib/auth';
 import { redirect } from 'next/navigation';
+import { cookies } from 'next/headers';
+import TenantRedirect from './TenantRedirect';
 import DevSignIn from '@/components/auth/DevSignIn';
 import nextDynamic from 'next/dynamic';
 import { Suspense } from 'react';
@@ -22,7 +24,20 @@ const VoidScene = nextDynamic(() => import('@/components/void/VoidScene'), {
 export default async function LoginPage() {
   const authOptions = getAuthOptions();
   const session = await getServerSession(authOptions);
-  if (session) redirect('/' + (session.user?.tenant ?? 'demo') + '/dashboard');
+  if (session) {
+    const tenant = session.user?.tenant ?? 'demo';
+    // ensure cookie exists for middleware; set server-side as fallback
+    cookies().set({
+      name: 'cda_tenant',
+      value: tenant,
+      httpOnly: true,
+      sameSite: 'lax',
+      secure: process.env.NODE_ENV === 'production',
+      path: '/',
+      maxAge: 60 * 60 * 24 * 30,
+    });
+    return <TenantRedirect tenant={tenant} />;
+  }
 
   const googleEnabled = authOptions.providers.some((p) => p.id === 'google');
 

--- a/docker/web-app/src/components/TopBar.ServiceStatusChip.tsx
+++ b/docker/web-app/src/components/TopBar.ServiceStatusChip.tsx
@@ -1,0 +1,31 @@
+'use client'
+import { AppConfig } from '../lib/config'
+import { useEffect, useState } from 'react'
+
+export function labelFor(ok: null | boolean) {
+  return ok === null ? 'Local-only' : ok ? 'media-api: OK' : 'media-api: down'
+}
+
+export async function probeMediaApi(): Promise<null | boolean> {
+  if (!AppConfig.mediaApiBase) return null
+  try {
+    const res = await fetch(`${AppConfig.mediaApiBase}/health`, { cache: 'no-store' })
+    return res.ok
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Displays status of media-api service.
+ *
+ * Example:
+ *   <ServiceStatusChip />
+ */
+export default function ServiceStatusChip() {
+  const [ok, setOk] = useState<null | boolean>(null)
+  useEffect(() => { probeMediaApi().then(setOk) }, [])
+  return (
+    <span className="text-xs px-2 py-1 rounded border">{labelFor(ok)}</span>
+  )
+}

--- a/docker/web-app/src/components/TopBar.tsx
+++ b/docker/web-app/src/components/TopBar.tsx
@@ -9,6 +9,7 @@ import { useModal } from '@/providers/ModalProvider'
 import { useTheme, AVAILABLE_SCHEMES, ColorScheme } from '@/context/ThemeContext'
 import { useAuth } from '@/providers/AuthProvider'
 import { useIsClient } from '@/hooks/useIsClient'
+import ServiceStatusChip from './TopBar.ServiceStatusChip'
 
 export default function TopBar() {
   const { collapsed, setCollapsed } = useSidebar()
@@ -63,6 +64,7 @@ export default function TopBar() {
             <option key={opt} value={opt}>{opt}</option>
           ))}
         </select>
+        <ServiceStatusChip />
         <button
           type="button"
           disabled={!isClient}

--- a/docker/web-app/src/components/__tests__/TopBar.ServiceStatusChip.test.tsx
+++ b/docker/web-app/src/components/__tests__/TopBar.ServiceStatusChip.test.tsx
@@ -1,0 +1,26 @@
+/**
+ * Tests for ServiceStatusChip helpers.
+ * Run with: npm test
+ */
+import assert from 'node:assert'
+import test from 'node:test'
+import { labelFor, probeMediaApi } from '../TopBar.ServiceStatusChip'
+import { AppConfig } from '../../lib/config'
+
+test('labelFor maps states to strings', () => {
+  assert.equal(labelFor(null), 'Local-only')
+  assert.equal(labelFor(true), 'media-api: OK')
+  assert.equal(labelFor(false), 'media-api: down')
+})
+
+test('probeMediaApi resolves status', async t => {
+  const origFetch = global.fetch
+  t.after(() => { global.fetch = origFetch })
+  ;(AppConfig as any).mediaApiBase = 'http://api'
+  global.fetch = async () => new Response('', { status: 200 })
+  assert.equal(await probeMediaApi(), true)
+  global.fetch = async () => { throw new Error('x') }
+  assert.equal(await probeMediaApi(), false)
+  ;(AppConfig as any).mediaApiBase = ''
+  assert.equal(await probeMediaApi(), null)
+})

--- a/docker/web-app/src/components/__tests__/TopBar.test.tsx
+++ b/docker/web-app/src/components/__tests__/TopBar.test.tsx
@@ -32,6 +32,11 @@ test('TopBar renders account menu button', () => {
   assert.ok(html.includes('Account menu'))
 })
 
+test('TopBar includes service status chip', () => {
+  const html = renderToString(<TopBar />)
+  assert.ok(html.includes('Local-only'))
+})
+
 test('Explorer button triggers dam-explorer modal', async () => {
   let opened: string | null = null
   modalMod.useModal = () => ({ openModal: (tool: string) => { opened = tool }, closeModal() {} })

--- a/docker/web-app/src/lib/tenancy/cookieClient.test.ts
+++ b/docker/web-app/src/lib/tenancy/cookieClient.test.ts
@@ -1,0 +1,21 @@
+/**
+ * Tests for cookieClient helpers.
+ * Run with: npm test
+ */
+import assert from 'node:assert'
+import test from 'node:test'
+import { setDefaultTenantCookie, clearDefaultTenantCookie } from './cookieClient'
+
+test('setDefaultTenantCookie surfaces errors', async t => {
+  const origFetch = global.fetch
+  t.after(() => { global.fetch = origFetch })
+  global.fetch = async () => new Response('nope', { status: 500 })
+  await assert.rejects(() => setDefaultTenantCookie('demo'))
+})
+
+test('clearDefaultTenantCookie surfaces errors', async t => {
+  const origFetch = global.fetch
+  t.after(() => { global.fetch = origFetch })
+  global.fetch = async () => new Response('nope', { status: 500 })
+  await assert.rejects(() => clearDefaultTenantCookie())
+})

--- a/docker/web-app/src/lib/tenancy/cookieClient.ts
+++ b/docker/web-app/src/lib/tenancy/cookieClient.ts
@@ -1,0 +1,20 @@
+/**
+ * Client helpers for managing the `cda_tenant` cookie via API routes.
+ *
+ * Usage:
+ *   await setDefaultTenantCookie('demo')
+ *   await clearDefaultTenantCookie()
+ */
+export async function setDefaultTenantCookie(slug: string) {
+  const res = await fetch('/api/account/set-default-tenant', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ slug }),
+  })
+  if (!res.ok) throw new Error('Failed to set default tenant')
+}
+
+export async function clearDefaultTenantCookie() {
+  const res = await fetch('/api/account/clear-default-tenant', { method: 'POST' })
+  if (!res.ok) throw new Error('Failed to clear default tenant')
+}


### PR DESCRIPTION
Milestone: 🧬 Feature Development
Scope: web-app, compose
Linked Issues: 

## Summary
- add web-app dev compose service with hot-reload volumes
- implement cookie-aware tenant middleware and service status chip
- expose APIs and helpers to manage default tenant cookie

## Testing
- `npm test` *(fails: CameraMonitor TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68acc504ca6083268c0d0b04bde1bb6e