### PR TITLE
fix: wrap login page client components

### DIFF
--- a/docker/web-app/src/app/__tests__/login.test.tsx
+++ b/docker/web-app/src/app/__tests__/login.test.tsx
@@ -29,3 +29,8 @@ test('LoginPage defers void scene to client', async () => {
   assert.ok(!html.includes('void-scene'));
 });
 
+test('LoginPage defers neon title to client', async () => {
+  const html = renderToString(await LoginPage());
+  assert.ok(!html.includes('THATDAMTOOLBOX'));
+});
+

--- a/docker/web-app/src/app/login/page.tsx
+++ b/docker/web-app/src/app/login/page.tsx
@@ -6,20 +6,11 @@ import { redirect } from 'next/navigation';
 import { cookies } from 'next/headers';
 import TenantRedirect from './TenantRedirect';
 import DevSignIn from '@/components/auth/DevSignIn';
-import nextDynamic from 'next/dynamic';
 import { Suspense } from 'react';
+import NeonTitle from '@/components/void/NeonTitle.client';
+import VoidScene from '@/components/void/VoidScene.client';
 
 export const dynamic = 'force-dynamic';
-
-// dynamic import for neon title on client
-const NeonTitle = nextDynamic(() => import('@/components/void/NeonTitle'), {
-  ssr: false,
-});
-
-// dynamic import for animated void scene; client only
-const VoidScene = nextDynamic(() => import('@/components/void/VoidScene'), {
-  ssr: false,
-});
 
 export default async function LoginPage() {
   const authOptions = getAuthOptions();

--- a/docker/web-app/src/components/void/NeonTitle.client.tsx
+++ b/docker/web-app/src/components/void/NeonTitle.client.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+/**
+ * Client-only wrapper for the NeonTitle component.
+ * Usage: <NeonTitle title="Hello" subtitle="World" />
+ */
+import dynamic from 'next/dynamic';
+
+const NeonTitle = dynamic(() => import('./NeonTitle'), { ssr: false });
+
+export default NeonTitle;

--- a/docker/web-app/src/components/void/VoidScene.client.tsx
+++ b/docker/web-app/src/components/void/VoidScene.client.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+/**
+ * Client-only wrapper for the VoidScene component.
+ * Usage: <VoidScene />
+ */
+import dynamic from 'next/dynamic';
+
+const VoidScene = dynamic(() => import('./VoidScene'), { ssr: false });
+
+export default VoidScene;


### PR DESCRIPTION
Milestone: 🧬 Feature Development
Scope: web-app
Linked Issues: none

## Summary
- wrap login page client components behind client-only dynamic imports to remove unsupported ssr option
- assert neon title rendered client-side

## Testing
- ❌ `npm run lint` (errors in unrelated files)
- ❌ `npm run type-check` (errors in unrelated files)
- ❌ `npm test` (type errors in unrelated files)


------
https://chatgpt.com/codex/tasks/task_e_68ace0b06f148326b641e98d72658998