### PR TITLE
fix(web-app): await cookies before setting tenant cookie

### DIFF
--- a/docker/web-app/src/app/__tests__/login.test.tsx
+++ b/docker/web-app/src/app/__tests__/login.test.tsx
@@ -34,3 +34,16 @@ test('LoginPage defers neon title to client', async () => {
   assert.ok(!html.includes('THATDAMTOOLBOX'));
 });
 
+test('LoginPage sets tenant cookie when session exists', async () => {
+  const auth = require('next-auth/next');
+  const original = auth.getServerSession;
+  auth.getServerSession = async () => ({ user: { tenant: 'demo' } });
+  const { cookies } = require('next/headers');
+  const store = await cookies();
+  store.setCalls = [];
+  await LoginPage();
+  assert.equal(store.setCalls.length, 1);
+  assert.equal(store.setCalls[0].name, 'cda_tenant');
+  auth.getServerSession = original;
+});
+

--- a/docker/web-app/src/app/login/page.tsx
+++ b/docker/web-app/src/app/login/page.tsx
@@ -18,7 +18,8 @@ export default async function LoginPage() {
   if (session) {
     const tenant = session.user?.tenant ?? 'demo';
     // ensure cookie exists for middleware; set server-side as fallback
-    cookies().set({
+    const cookieStore = await cookies();
+    cookieStore.set({
       name: 'cda_tenant',
       value: tenant,
       httpOnly: true,

--- a/docker/web-app/src/test/test-mocks.js
+++ b/docker/web-app/src/test/test-mocks.js
@@ -51,6 +51,22 @@ if (process.env.NODE_ENV === 'test') {
         useParams: () => ({}),
       });
     }
+    if (id === 'next/headers') {
+      return (
+        global.__nextHeaders ||= {
+          cookies: async () => {
+            const store =
+              (global.__cookieStore ||= {
+                setCalls: [],
+                set(opts) {
+                  this.setCalls.push(opts);
+                },
+              });
+            return store;
+          },
+        }
+      );
+    }
     if (id === 'react-devtools-core') {
       return { connectToDevTools: () => ({}), startServer: () => {} };
     }


### PR DESCRIPTION
Milestone: 🧬 Feature Development
Scope: web-app
Linked Issues: 

## Summary
- await cookies before setting tenant cookie on login
- add test verifying tenant cookie creation when session exists
- extend test mocks to stub Next.js cookies API

## Testing
- `npm test` (fails: TS errors in unrelated components)
- `npm run lint` (fails: lint errors)
- `npm run type-check` (fails: TS type errors)

## Checklist
- [x] Code is self-contained and idempotent.
- [x] No unnecessary new files or external dependencies.
- [x] Tests added or updated as appropriate.
- [ ] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_68ace7e990d483269bd00eecae3a4b30