### PR TITLE
feat(web-app): add provisioning button to access control

### DIFF
--- a/docker/web-app/src/app/[tenant]/access-control/__tests__/ProvisionButton.test.tsx
+++ b/docker/web-app/src/app/[tenant]/access-control/__tests__/ProvisionButton.test.tsx
@@ -1,0 +1,27 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import path from 'node:path';
+import React from 'react';
+
+const modalPath = path.resolve(__dirname, '../../../../providers/ModalProvider.js');
+const modalMod = require(modalPath);
+
+/**
+ * Verify provisioning modal trigger from access control page.
+ * Run with: npm test
+ */
+test('Provision Device button opens provisioning modal', async () => {
+  let opened: string | null = null;
+  modalMod.useModal = () => ({ openModal: (tool: string) => { opened = tool; }, closeModal() {} });
+  const pagePath = path.resolve(__dirname, '../page.js');
+  delete require.cache[pagePath];
+  const { default: Page } = await import('../page');
+  const el = Page({ params: { tenant: 't1' } });
+  const header = el.props.children[0];
+  const buttonStack = header.props.children[1];
+  const provisionBtn = buttonStack.props.children[0];
+  provisionBtn.props.onClick();
+  modalMod.useModal = () => ({ openModal() {}, closeModal() {} });
+  delete require.cache[pagePath];
+  assert.equal(opened, 'provision-device');
+});

--- a/docker/web-app/src/app/[tenant]/access-control/page.tsx
+++ b/docker/web-app/src/app/[tenant]/access-control/page.tsx
@@ -5,6 +5,7 @@
 
 import * as React from 'react';
 import { Box, Button, Container, Stack, Typography } from '@mui/material';
+import { useModal } from '@/providers/ModalProvider';
 import { MembersTable, type MemberRow } from '../../../components/access/MembersTable';
 import { InviteDialog } from '../../../components/access/InviteDialog';
 import { EditRolesDialog } from '../../../components/access/EditRolesDialog';
@@ -16,12 +17,23 @@ export default function AccessControlPage({ params }: { params: { tenant: string
   const [inviteOpen, setInviteOpen] = React.useState(false);
   const [editMember, setEditMember] = React.useState<MemberRow | null>(null);
   const [reloadKey, setReloadKey] = React.useState(0);
+  const { openModal } = useModal();
 
   return (
     <Container maxWidth="lg" sx={{ py: 3 }}>
       <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 2 }}>
         <Typography variant="h4">Access Control</Typography>
-        <Button variant="contained" onClick={() => setInviteOpen(true)}>Invite Member</Button>
+        <Stack direction="row" spacing={1}>
+          <Button
+            aria-label="Provision Device"
+            onClick={() => openModal('provision-device')}
+          >
+            Provision Device
+          </Button>
+          <Button variant="contained" onClick={() => setInviteOpen(true)}>
+            Invite Member
+          </Button>
+        </Stack>
       </Stack>
 
       <MembersTable


### PR DESCRIPTION
Milestone: 🧬 Feature Development
Scope: web-app
Linked Issues: n/a

## Summary
- enable device provisioning from access control page via new button and modal trigger
- add unit test ensuring provisioning modal opens on click

## Testing
- `npm test` *(fails: TS errors in unrelated files)*

## Checklist
- [x] Code is self-contained and idempotent.
- [x] No unnecessary new files or external dependencies.
- [x] Tests added or updated as appropriate.
- [ ] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_68ace8897a708326a78b2580393ede7b