### PR TITLE
fix: configure dev origins and defer tenant cookie

### DIFF
--- a/docker/web-app/README.md
+++ b/docker/web-app/README.md
@@ -308,7 +308,12 @@ NEXTAUTH_URL=http://localhost:3000
 NEXTAUTH_SECRET=changeme
 # Set to "true" to enable verbose NextAuth logs
 NEXTAUTH_DEBUG=false
+NEXT_DEV_ALLOWED_ORIGINS=http://192.168.0.22:3000
 ```
+
+`NEXT_DEV_ALLOWED_ORIGINS` is a comma-separated list of origins allowed to
+request Next.js assets in development, useful when testing from other LAN
+devices.
 
 ## API Mappings
 

--- a/docker/web-app/next.config.mjs
+++ b/docker/web-app/next.config.mjs
@@ -115,7 +115,9 @@ export default function nextConfig(phase) {
       allowedDevOrigins: [
         'http://localhost:3000',
         'http://127.0.0.1:3000',
-        'http://192.168.0.22:3000',
+        ...(process.env.NEXT_DEV_ALLOWED_ORIGINS
+          ? process.env.NEXT_DEV_ALLOWED_ORIGINS.split(',')
+          : []),
       ],
     };
   }

--- a/docker/web-app/src/app/__tests__/login.test.tsx
+++ b/docker/web-app/src/app/__tests__/login.test.tsx
@@ -7,6 +7,7 @@ import assert from 'node:assert';
 import test from 'node:test';
 import { renderToString } from 'react-dom/server';
 import LoginPage from '../login/page';
+import TenantRedirect from '../login/TenantRedirect';
 
 test('LoginPage shows development sign in when Google is missing', async () => {
   delete process.env.GOOGLE_CLIENT_ID;
@@ -34,16 +35,12 @@ test('LoginPage defers neon title to client', async () => {
   assert.ok(!html.includes('THATDAMTOOLBOX'));
 });
 
-test('LoginPage sets tenant cookie when session exists', async () => {
+test('LoginPage redirects authenticated users via TenantRedirect', async () => {
   const auth = require('next-auth/next');
   const original = auth.getServerSession;
   auth.getServerSession = async () => ({ user: { tenant: 'demo' } });
-  const { cookies } = require('next/headers');
-  const store = await cookies();
-  store.setCalls = [];
-  await LoginPage();
-  assert.equal(store.setCalls.length, 1);
-  assert.equal(store.setCalls[0].name, 'cda_tenant');
+  const el = await LoginPage();
+  assert.equal((el as any)?.type, TenantRedirect);
   auth.getServerSession = original;
 });
 

--- a/docker/web-app/src/app/login/page.tsx
+++ b/docker/web-app/src/app/login/page.tsx
@@ -2,8 +2,6 @@
 import GoogleGISButton from '@/components/auth/GoogleGISButton';
 import { getServerSession } from 'next-auth/next';
 import { getAuthOptions } from '@/lib/auth';
-import { redirect } from 'next/navigation';
-import { cookies } from 'next/headers';
 import TenantRedirect from './TenantRedirect';
 import DevSignIn from '@/components/auth/DevSignIn';
 import { Suspense } from 'react';
@@ -17,17 +15,7 @@ export default async function LoginPage() {
   const session = await getServerSession(authOptions);
   if (session) {
     const tenant = session.user?.tenant ?? 'demo';
-    // ensure cookie exists for middleware; set server-side as fallback
-    const cookieStore = await cookies();
-    cookieStore.set({
-      name: 'cda_tenant',
-      value: tenant,
-      httpOnly: true,
-      sameSite: 'lax',
-      secure: process.env.NODE_ENV === 'production',
-      path: '/',
-      maxAge: 60 * 60 * 24 * 30,
-    });
+    // cookie is set client-side via TenantRedirect
     return <TenantRedirect tenant={tenant} />;
   }
 


### PR DESCRIPTION
Milestone: 🧬 Feature Development
Scope: web-app
Linked Issues: N/A

## Summary
- Defer tenant cookie to client redirect to comply with Next.js rules
- Allow configuring additional dev origins via NEXT_DEV_ALLOWED_ORIGINS
- Document new env var for dev origins

## Testing
- `npm test` *(fails: TypeScript compilation errors in unrelated components)*
- `npm run lint` *(fails: existing lint errors)*

## Checklist
- [ ] Code is self-contained and idempotent.
- [ ] No unnecessary new files or external dependencies.
- [ ] Tests added or updated as appropriate.
- [ ] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_68ad0a6c8f648326a0ee98d5229c0258