### PR TITLE
fix: sync tenant cookie and account menu logic

### DIFF
--- a/docker/web-app/src/components/TopBar.tsx
+++ b/docker/web-app/src/components/TopBar.tsx
@@ -29,6 +29,25 @@ export default function TopBar() {
     return () => document.removeEventListener('keydown', onKey)
   }, [menuOpen])
 
+  useEffect(() => {
+    if (!menuOpen) return
+    const handle = (e: MouseEvent | TouchEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setMenuOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handle)
+    document.addEventListener('touchstart', handle)
+    return () => {
+      document.removeEventListener('mousedown', handle)
+      document.removeEventListener('touchstart', handle)
+    }
+  }, [menuOpen])
+
+  useEffect(() => {
+    if (!user) setMenuOpen(false)
+  }, [user])
+
   return (
     <header
       className={clsx(
@@ -73,46 +92,48 @@ export default function TopBar() {
         >
           Explorer
         </button>
-        <div className="relative" ref={menuRef}>
-          <button
-            aria-haspopup="menu"
-            aria-expanded={menuOpen}
-            aria-label="Account menu"
-            className="w-8 h-8 rounded-full bg-color-primary-bg text-sm flex items-center justify-center"
-            onClick={() => setMenuOpen(o => !o)}
-          >
-            {user?.name?.[0] ?? 'U'}
-          </button>
-          {menuOpen && (
-            <div
-              role="menu"
-              tabIndex={-1}
-              className="absolute right-0 mt-2 bg-surface border border-color-border rounded shadow-md"
-              onBlur={e => {
-                if (!e.currentTarget.contains(e.relatedTarget as Node)) setMenuOpen(false)
-              }}
+        {user && (
+          <div className="relative" ref={menuRef}>
+            <button
+              aria-haspopup="menu"
+              aria-expanded={menuOpen}
+              aria-label="Account menu"
+              className="w-8 h-8 rounded-full bg-color-primary-bg text-sm flex items-center justify-center"
+              onClick={() => setMenuOpen(o => !o)}
             >
-              <a
-                href="/account"
-                role="menuitem"
-                className="block px-4 py-2 text-sm hover:bg-color-primary-bg"
-                onClick={() => setMenuOpen(false)}
-              >
-                Account
-              </a>
-              <button
-                role="menuitem"
-                className="block w-full text-left px-4 py-2 text-sm hover:bg-color-primary-bg"
-                onClick={() => {
-                  logout()
-                  setMenuOpen(false)
+              {user.name?.[0] ?? 'U'}
+            </button>
+            {menuOpen && (
+              <div
+                role="menu"
+                tabIndex={-1}
+                className="absolute right-0 mt-2 bg-surface border border-color-border rounded shadow-md"
+                onBlur={e => {
+                  if (!e.currentTarget.contains(e.relatedTarget as Node)) setMenuOpen(false)
                 }}
               >
-                Logout
-              </button>
-            </div>
-          )}
-        </div>
+                <a
+                  href="/account"
+                  role="menuitem"
+                  className="block px-4 py-2 text-sm hover:bg-color-primary-bg"
+                  onClick={() => setMenuOpen(false)}
+                >
+                  Account
+                </a>
+                <button
+                  role="menuitem"
+                  className="block w-full text-left px-4 py-2 text-sm hover:bg-color-primary-bg"
+                  onClick={() => {
+                    logout()
+                    setMenuOpen(false)
+                  }}
+                >
+                  Logout
+                </button>
+              </div>
+            )}
+          </div>
+        )}
       </nav>
     </header>
   );

--- a/docker/web-app/src/components/__tests__/TopBar.test.tsx
+++ b/docker/web-app/src/components/__tests__/TopBar.test.tsx
@@ -44,7 +44,7 @@ test('Explorer button triggers dam-explorer modal', async () => {
   const { default: TestTopBar } = await import('../TopBar')
   const el = TestTopBar()
   const nav = el.props.children[1]
-  const button = nav.props.children[1]
+  const button = nav.props.children[2]
   button.props.onClick()
   modalMod.useModal = () => ({ openModal() {}, closeModal() {} })
   delete require.cache[topBarPath]
@@ -58,7 +58,7 @@ test('Account menu logout triggers logout handler', async () => {
   const { default: TestTopBar } = await import('../TopBar')
   const el = TestTopBar()
   const nav = el.props.children[1]
-  const menuWrapper = nav.props.children[2]
+  const menuWrapper = nav.props.children[3]
   const button = menuWrapper.props.children[0]
   button.props.onClick()
   const menu = menuWrapper.props.children[1]
@@ -67,4 +67,32 @@ test('Account menu logout triggers logout handler', async () => {
   authMod.useAuth = () => ({ user: { name: 'A' }, logout() {} })
   delete require.cache[topBarPath]
   assert.ok(loggedOut)
+})
+
+test('Account menu hidden when user missing', () => {
+  authMod.useAuth = () => ({ user: null, logout() {} })
+  delete require.cache[topBarPath]
+  const { default: TestTopBar } = require(topBarPath)
+  const html = renderToString(<TestTopBar />)
+  authMod.useAuth = () => ({ user: { name: 'A' }, logout() {} })
+  delete require.cache[topBarPath]
+  assert.ok(!html.includes('Account menu'))
+})
+
+test('Click outside closes account menu', async () => {
+  const events: Record<string, (e: any) => void> = {}
+  ;(global as any).document = {
+    addEventListener: (t: string, cb: any) => { events[t] = cb },
+    removeEventListener: (t: string) => { delete events[t] },
+  }
+  delete require.cache[topBarPath]
+  const { default: TestTopBar } = await import('../TopBar')
+  const el = TestTopBar()
+  const nav = el.props.children[1]
+  const menuWrapper = nav.props.children[3]
+  const button = menuWrapper.props.children[0]
+  button.props.onClick()
+  events['mousedown']({ target: {} })
+  assert.ok(!events['mousedown'])
+  delete (global as any).document
 })


### PR DESCRIPTION
Milestone: 🧬 Feature Development
Scope: docker/web-app
Linked Issues: 

## Summary
- align AuthProvider tenant state with cda_tenant cookie on login/logout
- hide TopBar account menu when user missing and add outside-click dismissal

## Testing
- `npm test` *(fails: TypeScript compilation errors in CameraMonitor and related files)*


------
https://chatgpt.com/codex/tasks/task_e_68ad0f8f90b0832699ad2ff6251f96ec